### PR TITLE
Fix App Check token handling

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,6 +4,7 @@ import 'package:cloud_functions/cloud_functions.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fb;
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_core/firebase_core.dart'; // ignore: unnecessary_import
 import 'package:flutter/foundation.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
@@ -139,9 +140,14 @@ class AuthService {
     debugPrint('[REGISTER] registerWithEmail STARTED');
     debugPrint('🔵 registerWithEmail() STARTED');
     try {
-      final appCheckToken = await _appCheck.getToken(true);
-      if (kDebugMode) {
-        debugPrint('[APP_CHECK] token: $appCheckToken');
+      // App Check token lekérése. Debug / teszt buildben
+      // nem szakítjuk meg a flow-t, ha a backend 403-at dob.
+      try {
+        await _appCheck.getToken(true);
+      } on FirebaseException catch (e) {
+        if (kDebugMode) {
+          debugPrint('[APP_CHECK] getToken FAILED – ignore (${e.code})');
+        }
       }
 
       final cred = await _firebaseAuth.createUserWithEmailAndPassword(

--- a/test/services/auth_service_appcheck_test.dart
+++ b/test/services/auth_service_appcheck_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:tippmixapp/services/auth_service.dart';
+
+class _MockAppCheck extends Mock implements FirebaseAppCheck {}
+
+class _MockFirebaseAuth extends Mock implements fb.FirebaseAuth {}
+
+class _MockUserCredential extends Mock implements fb.UserCredential {}
+
+class _MockUser extends Mock implements fb.User {}
+
+void main() {
+  group('AuthService.registerWithEmail', () {
+    test('does not throw if getToken() fails', () async {
+      final mockAuth = _MockFirebaseAuth();
+      final mockAppCheck = _MockAppCheck();
+      when(
+        mockAppCheck.getToken(any),
+      ).thenThrow(FirebaseException(plugin: 'firebase_app_check', code: '403'));
+
+      final cred = _MockUserCredential();
+      final user = _MockUser();
+      when(cred.user).thenReturn(user);
+      when(
+        mockAuth.createUserWithEmailAndPassword(
+          email: 'a@b.c',
+          password: 'pw123456',
+        ),
+      ).thenAnswer((_) async => cred);
+
+      final service = AuthService(
+        firebaseAuth: mockAuth,
+        appCheck: mockAppCheck,
+      );
+
+      await expectLater(
+        () => service.registerWithEmail('a@b.c', 'pw123456'),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- handle Firebase App Check token failures gracefully
- add unit test covering the new behavior

## Testing
- `flutter analyze --no-pub lib test`
- `flutter test --coverage` *(fails: No Firebase App '[DEFAULT]' has been created)*

------
https://chatgpt.com/codex/tasks/task_e_688baf15de20832f9b44591817a98436