### PR TITLE
Fix App Check error handling for registration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,9 +72,12 @@ Future<void> main() async {
   );
 
   if (kDebugMode) {
-  // Mindig friss tokent kérünk és kiírjuk, ha van
-  final debugToken = await FirebaseAppCheck.instance.getToken(true);
-  debugPrint('🔐 DEBUG App Check token: ${debugToken ?? 'NULL (nem érkezett)'}');
+    try {
+      final debugToken = await FirebaseAppCheck.instance.getToken(true);
+      debugPrint('🔐 DEBUG App Check token: ${debugToken ?? 'NULL'}');
+    } on FirebaseException catch (e) {
+      debugPrint('[APP_CHECK] startup getToken FAILED – ignore (${e.code})');
+    }
   }
 
   // --- end debug token configuration ---

--- a/test/services/auth_service_appcheck_test.dart
+++ b/test/services/auth_service_appcheck_test.dart
@@ -2,38 +2,83 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:tippmixapp/services/auth_service.dart';
 
-class _MockAppCheck extends Mock implements FirebaseAppCheck {}
+class _FailingAppCheck extends Fake implements FirebaseAppCheck {
+  @override
+  Future<String?> getToken([bool? autoRefresh = false]) {
+    return Future.error(
+      FirebaseException(plugin: 'firebase_app_check', code: '403'),
+    );
+  }
+}
 
-class _MockFirebaseAuth extends Mock implements fb.FirebaseAuth {}
+class _FakeFirebaseAuth extends Fake implements fb.FirebaseAuth {
+  final fb.UserCredential credential;
+
+  _FakeFirebaseAuth(this.credential);
+
+  @override
+  Future<fb.UserCredential> createUserWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {
+    return credential;
+  }
+}
 
 class _MockUserCredential extends Mock implements fb.UserCredential {}
 
-class _MockUser extends Mock implements fb.User {}
+class FakeUser extends Fake implements fb.User {
+  @override
+  String get uid => 'uid';
+
+  @override
+  String? get email => 'user@test.com';
+
+  @override
+  String? get displayName => 'User';
+
+  @override
+  Future<void> sendEmailVerification([
+    fb.ActionCodeSettings? actionCodeSettings,
+  ]) async {}
+}
+
+class FakeHttpsCallable extends Fake implements HttpsCallable {
+  @override
+  Future<HttpsCallableResult<T>> call<T>([dynamic parameters]) async {
+    return FakeHttpsCallableResult<T>(null as T);
+  }
+}
+
+class FakeHttpsCallableResult<T> implements HttpsCallableResult<T> {
+  @override
+  final T data;
+  FakeHttpsCallableResult(this.data);
+}
+
+class FakeFirebaseFunctions extends Fake implements FirebaseFunctions {
+  @override
+  HttpsCallable httpsCallable(String name, {HttpsCallableOptions? options}) {
+    return FakeHttpsCallable();
+  }
+}
 
 void main() {
   group('AuthService.registerWithEmail', () {
     test('does not throw if getToken() fails', () async {
-      final mockAuth = _MockFirebaseAuth();
-      final mockAppCheck = _MockAppCheck();
-      when(
-        mockAppCheck.getToken(any),
-      ).thenThrow(FirebaseException(plugin: 'firebase_app_check', code: '403'));
-
       final cred = _MockUserCredential();
-      final user = _MockUser();
+      final mockAuth = _FakeFirebaseAuth(cred);
+      final failingAppCheck = _FailingAppCheck();
+      final user = FakeUser();
       when(cred.user).thenReturn(user);
-      when(
-        mockAuth.createUserWithEmailAndPassword(
-          email: 'a@b.c',
-          password: 'pw123456',
-        ),
-      ).thenAnswer((_) async => cred);
 
       final service = AuthService(
         firebaseAuth: mockAuth,
-        appCheck: mockAppCheck,
+        appCheck: failingAppCheck,
+        functions: FakeFirebaseFunctions(),
       );
 
       await expectLater(


### PR DESCRIPTION
## Summary
- wrap debug App Check token retrieval in main.dart
- use fake App Check and Firebase services in test
- ensure registration doesn't crash when getToken fails

## Testing
- `dart format --set-exit-if-changed lib test`
- `flutter analyze lib test --no-pub`
- `flutter test test/services/auth_service_appcheck_test.dart`
- `flutter test --coverage` *(fails: Service connection disposed)*

------
https://chatgpt.com/codex/tasks/task_e_688bc0e91e9c832fb6b4f35d78bf69a4