### PR TITLE
Fix App Check missing debug token

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,12 +53,15 @@ Future<void> main() async {
     defaultValue: '',
   );
 
-  assert(
-    !kDebugMode || debugToken.isNotEmpty,
-    '⚠️  FIREBASE_APP_CHECK_DEBUG_TOKEN nincs megadva!\n'
-    'Adj meg --dart-define paramétert a build parancsban, '
-    'és állítsd be a környezeti változót a natív plugin számára (lásd launch.json).',
-  );
+  // Do not halt execution if the compile-time debug token is missing. The
+  // native plugin can still read the token from the
+  // `FIREBASE_APP_CHECK_DEBUG_TOKEN` environment variable.
+  if (kDebugMode && debugToken.isEmpty) {
+    debugPrint(
+      '⚠️  FIREBASE_APP_CHECK_DEBUG_TOKEN compile-time value missing – '
+      'folytatom futást (env változó még tartalmazhat tokent).',
+    );
+  }
 
   // Activate App Check. In debug mode the Android/iOS provider is set
   // accordingly. The debug token is picked up automatically by the native


### PR DESCRIPTION
## Summary
- avoid assertion crash when debug token not passed

## Testing
- `./flutter/bin/flutter test --coverage` *(fails: getSourceReport Service connection disposed)*

------
https://chatgpt.com/codex/tasks/task_e_688bd5bd5e80832fafe988bd15021751