### PR TITLE
feat: add wallets and tickets firestore rules

### DIFF
--- a/docs/backend/security_rules_en.md
+++ b/docs/backend/security_rules_en.md
@@ -16,11 +16,8 @@ This document defines the security model and Firestore access rules for TippmixA
 
 ```
 users/{uid}
-  → UserModel
-  → coin_logs/{logId} (planned)
-
-tickets/{uid}/{ticketId}
-  → TicketModel
+wallets/{uid}
+tickets/{ticketId}
 ```
 
 ---
@@ -33,13 +30,22 @@ service cloud.firestore {
   match /databases/{db}/documents {
 
     match /users/{userId} {
-      allow read, write: if request.auth.uid == userId;
+      allow read:  if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
-    match /tickets/{userId}/{ticketId} {
-      allow read: if request.auth.uid == userId;
-      allow write: if request.auth.uid == userId &&
-                    request.resource.data.userId == request.auth.uid;
+    match /wallets/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false;
+    }
+
+    match /tickets/{ticketId} {
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.keys().hasOnly([
+          'userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+      allow read: if request.auth != null;
+      allow update, delete: if false;
     }
   }
 }

--- a/docs/backend/security_rules_hu.md
+++ b/docs/backend/security_rules_hu.md
@@ -16,11 +16,8 @@ Ez a dokumentum rögzíti a TippmixApp Firestore adatbázisra vonatkozó jogosul
 
 ```
 users/{uid}
-  → UserModel
-  → coin_logs/{logId} (tervezett)
-
-tickets/{uid}/{ticketId}
-  → TicketModel
+wallets/{uid}
+tickets/{ticketId}
 ```
 
 ---
@@ -33,13 +30,22 @@ service cloud.firestore {
   match /databases/{db}/documents {
 
     match /users/{userId} {
-      allow read, write: if request.auth.uid == userId;
+      allow read:  if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
-    match /tickets/{userId}/{ticketId} {
-      allow read: if request.auth.uid == userId;
-      allow write: if request.auth.uid == userId &&
-                    request.resource.data.userId == request.auth.uid;
+    match /wallets/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false;
+    }
+
+    match /tickets/{ticketId} {
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.keys().hasOnly([
+          'userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+      allow read: if request.auth != null;
+      allow update, delete: if false;
     }
   }
 }

--- a/firebase.rules
+++ b/firebase.rules
@@ -47,17 +47,33 @@ service cloud.firestore {
       // Törlés tiltva
       allow delete: if false;
     }
-
-    // user dokumentum
+    /* ——— users ——— */
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
-      // subcollection
-      match /settings/{docId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
-      }
+      // Leaderboard‑hoz minden bejelentkezett user olvashat, írni csak a tulajdonos
+      allow read:  if signedIn();
+      allow write: if isOwner(userId);
+      // subcollection (settings, badges, stb.) örökli a jogot
     }
 
+    /* ——— wallets ——— */
+    match /wallets/{userId} {
+      allow read, write: if isOwner(userId);
+      allow delete: if false;
+    }
 
+    /* ——— tickets ——— */
+    match /tickets/{ticketId} {
+      // CREATE: csak saját szelvény, fix mezők
+      allow create: if signedIn()
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.keys().hasOnly(['userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+
+      // READ: leaderboard és saját szelvények megtekintéséhez
+      allow read: if signedIn();
+
+      // UPDATE/DELETE: tiltva kliens oldalon (server‑side Cloud Function frissítheti)
+      allow update, delete: if false;
+    }
 
     /* ——— badges (publikus read) ——— */
     match /badges/{badgeId} {


### PR DESCRIPTION
## Summary
- expand Firestore security rules for users, wallets and tickets collections
- document new access model in EN/HU docs

## Testing
- `./scripts/lint_docs.sh`
- `./flutter/bin/flutter analyze lib/ test/`
- `./flutter/bin/flutter test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688e9e4c0c58832f81019054d94254a4