### PR TITLE
fix(security): allow ticket creation

### DIFF
--- a/codex_docs/codex_readme_en.md
+++ b/codex_docs/codex_readme_en.md
@@ -62,3 +62,4 @@
 | ------------ | --------------- | -------------------------------------------------------------------------------- |
 | 2025‑07‑29   | @docs‑bot       | Első README létrehozva, bilingvális struktúra / Initial bilingual README created |
 | 2025‑08‑03   | @codex-bot      | TOC refreshed after security rules update                                       |
+| 2025‑08‑03   | @codex-bot      | TOC refreshed after ticket permissions fix                                      |

--- a/docs/backend/security_rules_en.md
+++ b/docs/backend/security_rules_en.md
@@ -19,6 +19,7 @@ This document defines the security model and Firestore access rules for TippmixA
 ```
 users/{uid}
   badges/{badgeId}
+  settings/{settingId}
 wallets/{uid}
 tickets/{ticketId}
 public_feed/{postId}
@@ -50,7 +51,7 @@ service cloud.firestore {
       allow create: if request.auth != null
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.keys().hasOnly([
-          'userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+          'id','userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
       allow read: if request.auth != null;
       allow update, delete: if false;
     }
@@ -75,6 +76,10 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow create: if request.auth != null && request.auth.uid == userId;
       allow update, delete: if false;
+    }
+
+    match /users/{userId}/settings/{settingId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
     match /copied_bets/{userId} {

--- a/docs/backend/security_rules_hu.md
+++ b/docs/backend/security_rules_hu.md
@@ -19,6 +19,7 @@ Ez a dokumentum rögzíti a TippmixApp Firestore adatbázisra vonatkozó jogosul
 ```
 users/{uid}
   badges/{badgeId}
+  settings/{settingId}
 wallets/{uid}
 tickets/{ticketId}
 public_feed/{postId}
@@ -50,7 +51,7 @@ service cloud.firestore {
       allow create: if request.auth != null
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.keys().hasOnly([
-          'userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+          'id','userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
       allow read: if request.auth != null;
       allow update, delete: if false;
     }
@@ -75,6 +76,10 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow create: if request.auth != null && request.auth.uid == userId;
       allow update, delete: if false;
+    }
+
+    match /users/{userId}/settings/{settingId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
     match /copied_bets/{userId} {

--- a/firebase.rules
+++ b/firebase.rules
@@ -36,9 +36,14 @@ service cloud.firestore {
     match /tickets/{ticketId} {
       allow create: if signedIn()
         && request.resource.data.userId == request.auth.uid
-        && request.resource.data.keys().hasOnly(['userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
+        && request.resource.data.keys().hasOnly(['id','userId','tips','stake','totalOdd','potentialWin','createdAt','updatedAt','status']);
       allow read: if signedIn();
       allow update, delete: if false;
+    }
+
+    /*  ─── Felhasználói beállítások alkollekció ───  */
+    match /users/{userId}/settings/{settingId} {
+      allow read, write: if isOwner(userId);
     }
 
     /* --- public_feed --- */

--- a/test/security_rules.test.mjs
+++ b/test/security_rules.test.mjs
@@ -164,4 +164,31 @@ describe('Firestore security rules', () => {
       })
     );
   });
+
+  // SR‑13 — user can create his own ticket
+  it('SR-13 tickets create saját uid OK', async () => {
+    const db = authed('user1');
+    const id = `user1_${Date.now()}`;
+    await assertSucceeds(
+      setDoc(doc(db, `tickets/${id}`), {
+        id,
+        userId: 'user1',
+        tips: [],
+        stake: 5,
+        totalOdd: 2.4,
+        potentialWin: 12,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        status: 'open',
+      })
+    );
+  });
+
+  // SR‑14 — user can read & write his own settings
+  it('SR-14 settings read/write saját uid OK', async () => {
+    const db = authed('user1');
+    const ref = doc(db, 'users/user1/settings/theme');
+    await assertSucceeds(setDoc(ref, { value: 'dark' }));
+    await assertSucceeds(getDoc(ref));
+  });
 });


### PR DESCRIPTION
## Summary
- include `id` in ticket write validation and permit users to manage their own settings documents
- add Firestore rule tests for ticket creation and settings read/write
- document ticket `id` and `settings` rules in both EN & HU guides

## Testing
- `npm run test:security` *(fails: Missing script "test:security")*
- `npm run test:rules`
- `./scripts/lint_docs.sh`
- `./scripts/precommit.sh` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f80a47114832fa542b505fd0815e1