### PR TITLE
fix(coin): enforce atomic ticket creation

### DIFF
--- a/codex_docs/codex_readme_en.md
+++ b/codex_docs/codex_readme_en.md
@@ -63,3 +63,4 @@
 | 2025‑07‑29   | @docs‑bot       | Első README létrehozva, bilingvális struktúra / Initial bilingual README created |
 | 2025‑08‑03   | @codex-bot      | TOC refreshed after security rules update                                       |
 | 2025‑08‑03   | @codex-bot      | TOC refreshed after ticket permissions fix                                      |
+| 2025‑08‑03   | @codex-bot      | TOC refreshed after coin integrity update                                       |

--- a/docs/backend/coin_service_logic_en.md
+++ b/docs/backend/coin_service_logic_en.md
@@ -22,8 +22,15 @@ TippCoin is used as a betting stake and gamification reward.
 
 ### On placing a ticket
 
-- Subtract stake amount from `user.tippCoin`
-- Block submission if not enough balance
+- A `debitAndCreateTicket()` method runs a Firestore transaction
+  that:
+  - reads the current balance from `wallets/{uid}.coins`;
+  - aborts with `FirebaseException(insufficient_coins)` if balance < stake;
+  - subtracts `stake` from both `wallets/{uid}.coins` and `users/{uid}.coins`;
+  - writes the new `tickets/{ticketId}` document in the same transaction.
+
+This guarantees atomicity – the user can never end up with a negative
+balance and a missing ticket.
 
 ### On result finalization
 
@@ -56,10 +63,11 @@ TippCoinLog {
 
 ## ⚠️ Current Status
 
-- Only static value exists in UserModel
-- No mutation logic implemented
-- No CoinService class or functions yet
-- No log collection defined
+- `CoinService.debitAndCreateTicket()` implemented for atomic stake
+  deduction and ticket creation.
+- Balance updates are visible immediately via `users/{uid}.coins` and
+  `wallets/{uid}.coins`.
+- Logging to `coin_logs` pending implementation.
 
 ---
 

--- a/docs/backend/coin_service_logic_hu.md
+++ b/docs/backend/coin_service_logic_hu.md
@@ -22,8 +22,13 @@ A TippCoin a fogadások tétje és a jutalmazás alapja.
 
 ### Szelvény beküldésekor
 
-- Levonás: `user.tippCoin -= stake`
-- Ha nincs elég egyenleg → blokkolás
+- A `debitAndCreateTicket()` metódus Firestore tranzakciót futtat, amely:
+  - beolvassa az aktuális egyenleget a `wallets/{uid}.coins` mezőből;
+  - ha az egyenleg < tét, `FirebaseException(insufficient_coins)` hibával megszakad;
+  - levonja a tétet mind a `wallets/{uid}.coins`, mind a `users/{uid}.coins` mezőből;
+  - ugyanebben a tranzakcióban létrehozza a `tickets/{ticketId}` dokumentumot.
+
+Ez garantálja az atomitást – a felhasználó nem kerülhet negatív egyenlegbe szelvény nélkül.
 
 ### Eredmény kiértékelésekor
 
@@ -56,9 +61,9 @@ TippCoinLog {
 
 ## ⚠️ Jelenlegi állapot
 
-- Csak statikus TippCoin mező van a UserModel-ben
-- Nincs CoinService osztály vagy logika
-- Nincs log kollekció vagy UI komponens
+- Megvalósult a `CoinService.debitAndCreateTicket()` atomikus levonás és szelvénylétrehozás.
+- Az egyenleg azonnal tükröződik a `users/{uid}.coins` és `wallets/{uid}.coins` dokumentumokon.
+- A `coin_logs` naplózás még hiányzik.
 
 ---
 

--- a/lib/screens/create_ticket_screen.dart
+++ b/lib/screens/create_ticket_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_core/firebase_core.dart';
 import '../providers/bet_slip_provider.dart';
 import '../models/tip_model.dart';
 import '../services/bet_slip_service.dart';
@@ -67,6 +68,19 @@ class _CreateTicketScreenState extends ConsumerState<CreateTicketScreen> {
           context,
         ).showSnackBar(SnackBar(content: Text(loc.ticket_submit_success)));
         Navigator.of(context).pop();
+      }
+    } on FirebaseException catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      if (e.code == 'insufficient_coins') {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Nincs elegendő TippCoin az egyenlegeden.'),
+          ),
+        );
+      } else {
+        rethrow;
       }
     } catch (e) {
       setState(() {

--- a/lib/services/bet_slip_service.dart
+++ b/lib/services/bet_slip_service.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
@@ -81,24 +80,7 @@ class BetSlipService {
     final cs =
         coinService ??
         CoinService(firestore: firestore ?? FirebaseFirestore.instance);
-    try {
-      await cs.debitCoin(
-        amount: stake,
-        reason: 'bet_stake',
-        transactionId: 'ticket_$ticketId',
-      );
-    } on FirebaseFunctionsException catch (e) {
-      if (e.code == 'unauthenticated') {
-        // Authentication required when using CoinService
-      }
-      rethrow;
-    }
-
-    // 5️⃣ Írás Firestore‑ba (transactions nélkül – S2‑3‑ban bővítjük)
-    final db = firestore ?? FirebaseFirestore.instance;
-    final ticketsRef = db.collection('tickets');
-
-    await ticketsRef.doc(ticketId).set(ticket.toJson());
+    await cs.debitAndCreateTicket(stake: stake, ticketData: ticket.toJson());
 
     if (kDebugMode) {
       debugPrint(

--- a/test/services/coin_balance_validation_test.dart
+++ b/test/services/coin_balance_validation_test.dart
@@ -1,0 +1,3 @@
+// TODO: Implement emulator-based test to assert:
+//  * insufficient coins throws FirebaseException(insufficient_coins)
+//  * sufficient coins deducts balance and creates ticket


### PR DESCRIPTION
## Summary
- ensure CoinService enforces atomic TippCoin deduction and ticket creation
- refactor BetSlipService to use debitAndCreateTicket
- show Snackbar on insufficient coin balance during ticket submission
- document atomic CoinService behaviour in EN & HU docs
- add coin balance validation test skeleton

## Testing
- `./scripts/lint_docs.sh` *(fails: markdownlint not installed)*
- `./scripts/precommit.sh` *(failed: command interrupted)*
- `dart format lib/services/coin_service.dart lib/services/bet_slip_service.dart lib/screens/create_ticket_screen.dart test/services/coin_balance_validation_test.dart`
- `flutter analyze` *(failed: 6945 issues)*
- `flutter test` *(interrupted)*
- `flutter test test/services/coin_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688fb743e610832f930f9caf4a674a18