### PR TITLE
fix: show Home grid instead of Feed on launch

### DIFF
--- a/docs/frontend/auth_strategy_en.md
+++ b/docs/frontend/auth_strategy_en.md
@@ -27,6 +27,7 @@ This document outlines the authentication system in **TippmixApp**, including Fi
 - `AuthController` – handles signIn, register, signOut
 - `auth_provider.dart` – exposes `authStateChanges` stream
 - `GoRouter` redirects based on auth state (`redirect:` logic)
+- `AuthGate` – guards private routes and is ignored on Home to let the grid render
 
 ## 🎯 Codex Rules
 

--- a/docs/frontend/auth_strategy_hu.md
+++ b/docs/frontend/auth_strategy_hu.md
@@ -27,6 +27,7 @@ Ez a dokumentum bemutatja a **TippmixApp** hitelesítési rendszerét: Firebase 
 - `AuthController` – belépés, regisztráció, kijelentkezés logika
 - `auth_provider.dart` – `authStateChanges` stream expozíció
 - `GoRouter` – `redirect:` használat auth állapot alapján
+- `AuthGate` – védi a privát útvonalakat, Home-on placeholderként kezeli a gridhez
 
 ## 🎯 Codex szabályok
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -21,6 +21,7 @@ import 'package:tippmixapp/services/challenge_service.dart';
 import 'package:tippmixapp/models/earned_badge_model.dart';
 import 'package:tippmixapp/providers/auth_provider.dart';
 import 'package:tippmixapp/routes/app_route.dart';
+import 'package:tippmixapp/ui/auth/auth_gate.dart';
 import 'package:tippmixapp/providers/feed_provider.dart';
 import 'package:tippmixapp/models/feed_model.dart';
 import 'home_guest_cta_tile.dart';
@@ -80,7 +81,8 @@ class HomeScreen extends ConsumerWidget {
     if (_isRootRoute(context) &&
         !showStats &&
         child != null &&
-        child is! SizedBox) {
+        child is! SizedBox &&
+        child is! AuthGate) {
       return child!;
     }
 


### PR DESCRIPTION
## Summary
- treat AuthGate as placeholder so HomeScreen grid shows on / route
- document AuthGate role in authentication strategy docs

## Testing
- `npx --yes markdown-toc -i codex_docs/codex_readme_en.md`
- `./scripts/lint_docs.sh`
- `./flutter/bin/flutter analyze lib test`
- `./flutter/bin/flutter test --tags=navigation` *(fails: No file or variants found for asset: .env)*

------
https://chatgpt.com/codex/tasks/task_e_689296893a24832f85557d1b92fd4547