### PR TITLE
fix: correct Terraform scheduler topic URIs and alert configs

### DIFF
--- a/infra/monitoring_alert.tf
+++ b/infra/monitoring_alert.tf
@@ -1,7 +1,6 @@
 resource "google_logging_metric" "remaining_credits_metric" {
   name   = "remaining_credits"
   filter = "jsonPayload.message:\"[quota]\""
-  value_extractor = "REGEXP_EXTRACT(jsonPayload.message, '\\[quota\\] remaining=(\\d+)')"
   metric_descriptor {
     metric_kind = "GAUGE"
     value_type  = "INT64"
@@ -19,7 +18,7 @@ resource "google_monitoring_alert_policy" "credit_low_alert" {
       filter          = "metric.type=\"logging.googleapis.com/user/remaining_credits\""
       comparison      = "COMPARISON_LT"
       threshold_value = var.quota_warn_at
-      duration        = "300s"   # 5 minutes
+      duration        = "300s" # 5 minutes
     }
   }
 

--- a/infra/notification_channel.tf
+++ b/infra/notification_channel.tf
@@ -3,6 +3,8 @@ resource "google_monitoring_notification_channel" "slack_channel" {
   type         = "slack"
 
   labels = {
-    token = var.slack_webhook_url
+    auth_token   = var.slack_webhook_url
+    channel_name = "general"
+    team         = "tippmixapp"
   }
 }

--- a/infra/scheduler_jobs.tf
+++ b/infra/scheduler_jobs.tf
@@ -3,13 +3,13 @@
 # -------------------------------------------------
 
 resource "google_cloud_scheduler_job" "kickoff_tracker" {
-  name             = "kickoff-tracker-job"
-  description      = "Publishes when matches about to start"
-  schedule         = var.kickoff_cron
-  time_zone        = "Europe/Budapest"
+  name        = "kickoff-tracker-job"
+  description = "Publishes when matches about to start"
+  schedule    = var.kickoff_cron
+  time_zone   = "Europe/Budapest"
 
   pubsub_target {
-    topic_name = google_pubsub_topic.result_check.name
+    topic_name = google_pubsub_topic.result_check.id
     data       = base64encode("{ \"job\": \"kickoff-tracker\" }")
   }
 }
@@ -21,7 +21,7 @@ resource "google_cloud_scheduler_job" "result_poller" {
   time_zone   = "Europe/Budapest"
 
   pubsub_target {
-    topic_name = google_pubsub_topic.result_check.name
+    topic_name = google_pubsub_topic.result_check.id
     data       = base64encode("{ \"job\": \"result-poller\" }")
   }
 }
@@ -33,7 +33,7 @@ resource "google_cloud_scheduler_job" "final_sweep" {
   time_zone   = "Europe/Budapest"
 
   pubsub_target {
-    topic_name = google_pubsub_topic.result_check.name
+    topic_name = google_pubsub_topic.result_check.id
     data       = base64encode("{ \"job\": \"final-sweep\" }")
   }
 }


### PR DESCRIPTION
## Summary
- ensure Cloud Scheduler jobs use full Pub/Sub topic URIs
- drop unsupported value_extractor on GAUGE metric
- update Slack notification channel labels with auth_token and metadata

## Testing
- `./scripts/lint_docs.sh`
- `terraform fmt -recursive`
- `terraform validate` *(fails: registry.terraform.io/hashicorp/google: there is no package ... cached)*
- `terraform plan -input=false -var environment=$ENV -var project_id=$GCLOUD_PROJECT_ID` *(fails: Required plugins are not installed)*
- `./scripts/precommit.sh` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba1eadb4832fa5fb6a0946712992