### PR TITLE
fix(infra): specify scheduler region and metric type

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,12 @@ Default: `assets/avatar/default_avatar.png` if provided.
 
 ---
 
+## ☁️ Infrastructure
+
+Terraform configuration expects a valid Slack webhook. When running `terraform apply`,
+pass a non-empty `-var slack_webhook_url=...` value or adjust
+`google_monitoring_notification_channel.slack_channel` to `count = 0` to skip creation.
+
+---
+
 For Codex configuration, see: [`AGENTS.md`](./AGENTS.md)

--- a/README_HU.md
+++ b/README_HU.md
@@ -125,4 +125,13 @@ Alapértelmezett avatar: `assets/avatar/default_avatar.png`
 
 ---
 
+## ☁️ Infrastruktúra
+
+A Terraform konfiguráció érvényes Slack webhookot igényel. `terraform apply`
+futtatásakor adj meg nem üres `-var slack_webhook_url=...` értéket,
+vagy állítsd a `google_monitoring_notification_channel.slack_channel`
+erőforrást `count = 0`-ra a kihagyáshoz.
+
+---
+
 A Codex konfigurációját lásd: [`AGENTS.md`](./AGENTS.md)

--- a/infra/monitoring_alert.tf
+++ b/infra/monitoring_alert.tf
@@ -2,7 +2,7 @@ resource "google_logging_metric" "remaining_credits_metric" {
   name   = "remaining_credits"
   filter = "jsonPayload.message:\"[quota]\""
   metric_descriptor {
-    metric_kind = "GAUGE"
+    metric_kind = "DELTA"
     value_type  = "INT64"
     unit        = "1"
   }

--- a/infra/scheduler_jobs.tf
+++ b/infra/scheduler_jobs.tf
@@ -7,6 +7,7 @@ resource "google_cloud_scheduler_job" "kickoff_tracker" {
   description = "Publishes when matches about to start"
   schedule    = var.kickoff_cron
   time_zone   = "Europe/Budapest"
+  region      = var.region
 
   pubsub_target {
     topic_name = google_pubsub_topic.result_check.id
@@ -19,6 +20,7 @@ resource "google_cloud_scheduler_job" "result_poller" {
   description = "Publishes periodic result polling trigger"
   schedule    = var.poll_cron
   time_zone   = "Europe/Budapest"
+  region      = var.region
 
   pubsub_target {
     topic_name = google_pubsub_topic.result_check.id
@@ -31,6 +33,7 @@ resource "google_cloud_scheduler_job" "final_sweep" {
   description = "Publishes catch‑all sweep trigger"
   schedule    = var.sweep_cron
   time_zone   = "Europe/Budapest"
+  region      = var.region
 
   pubsub_target {
     topic_name = google_pubsub_topic.result_check.id


### PR DESCRIPTION
## Summary
- add `region = var.region` for all Cloud Scheduler jobs
- switch logs-based metric to `DELTA`
- document Slack webhook requirement for Terraform

## Testing
- `terraform fmt -recursive`
- `terraform init` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: provider hashicorp/google not cached)*
- `terraform plan -input=false -var environment=$ENV -var project_id=$GCLOUD_PROJECT_ID -var region=$REGION` *(fails: Required plugins are not installed)*
- `./scripts/precommit.sh` *(fails: dart: command not found)*
- `flutter analyze` *(terminated manually)*
- `flutter test --coverage` *(fails: No file or variants found for asset: .env)*

------
https://chatgpt.com/codex/tasks/task_e_6895000bdd4c832fbc9af98ddde2479d