### PR TITLE
chore(infra): make slack notification optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,7 @@ Default: `assets/avatar/default_avatar.png` if provided.
 
 ## ☁️ Infrastructure
 
-Terraform configuration expects a valid Slack webhook. When running `terraform apply`,
-pass a non-empty `-var slack_webhook_url=...` value or adjust
-`google_monitoring_notification_channel.slack_channel` to `count = 0` to skip creation.
+Terraform includes an optional Slack webhook for alerts. `slack_webhook_url` defaults to an empty string, disabling the notification channel in dev/staging. To enable alerts, pass a non-empty token: `terraform apply -var slack_webhook_url=...`.
 
 ---
 

--- a/README_HU.md
+++ b/README_HU.md
@@ -127,10 +127,7 @@ Alapértelmezett avatar: `assets/avatar/default_avatar.png`
 
 ## ☁️ Infrastruktúra
 
-A Terraform konfiguráció érvényes Slack webhookot igényel. `terraform apply`
-futtatásakor adj meg nem üres `-var slack_webhook_url=...` értéket,
-vagy állítsd a `google_monitoring_notification_channel.slack_channel`
-erőforrást `count = 0`-ra a kihagyáshoz.
+A Terraform opcionális Slack webhookot használ riasztásokhoz. A `slack_webhook_url` alapértelmezésben üres, így a fejlesztői/staging környezetben nem jön létre értesítési csatorna. Ha szükség van Slack-riasztásokra, adj meg nem üres tokent: `terraform apply -var slack_webhook_url=...`.
 
 ---
 

--- a/infra/monitoring_alert.tf
+++ b/infra/monitoring_alert.tf
@@ -21,6 +21,5 @@ resource "google_monitoring_alert_policy" "credit_low_alert" {
       duration        = "300s" # 5 minutes
     }
   }
-
-  notification_channels = [google_monitoring_notification_channel.slack_channel.id]
+  notification_channels = var.slack_webhook_url == "" ? [] : [google_monitoring_notification_channel.slack_channel[0].id]
 }

--- a/infra/notification_channel.tf
+++ b/infra/notification_channel.tf
@@ -1,4 +1,5 @@
 resource "google_monitoring_notification_channel" "slack_channel" {
+  count        = var.slack_webhook_url == "" ? 0 : 1
   display_name = "Slack – OddsAPI quota"
   type         = "slack"
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -30,8 +30,10 @@ variable "sweep_cron" {
 
 
 variable "slack_webhook_url" {
-  description = "Slack incoming WebHook URL for alerts"
   type        = string
+  description = "Slack Bot User OAuth token (xoxb-…)"
+  default     = ""
+  # Leave empty in dev to disable Slack notification channel
 }
 
 variable "quota_warn_at" {


### PR DESCRIPTION
## Summary
- make slack webhook optional via default var and conditional channel
- skip alert channel when webhook unset
- document optional Slack webhook in README

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=infra init` *(fails: Failed to query available provider packages)*
- `terraform -chdir=infra validate` *(fails: no package for hashicorp/google cached)*
- `./scripts/lint_docs.sh`
- `./scripts/precommit.sh` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950a622994832fb0186df7cc9c4203