### PR TITLE
fix(match-finalizer): evaluate tips via collectionGroup

### DIFF
--- a/cloud_functions/lib/src/match_finalizer.js
+++ b/cloud_functions/lib/src/match_finalizer.js
@@ -4,24 +4,34 @@ exports.match_finalizer = void 0;
 const ResultProvider_1 = require("./services/ResultProvider");
 const CoinService_1 = require("./services/CoinService");
 const firebase_1 = require("./lib/firebase");
+const firestore_1 = require("firebase-admin/firestore");
 const resultProvider = new ResultProvider_1.ResultProvider();
 const coinService = new CoinService_1.CoinService();
 const match_finalizer = async (message) => {
     const payloadStr = Buffer.from(message.data || '', 'base64').toString('utf8');
     const { job } = JSON.parse(payloadStr);
     console.log(`[match_finalizer] received job: ${job}`);
-    // 1) Collect pending tickets + related eventIds
-    const ticketsSnap = await firebase_1.db.collection('tickets')
+    // 1) Collect pending tickets across all users via collectionGroup
+    // Tickets are stored under /tickets/{uid}/tickets/{ticketId}
+    const ticketsSnap = await firebase_1.db
+        .collectionGroup('tickets')
         .where('status', '==', 'pending')
+        .limit(200)
         .get();
     if (ticketsSnap.empty) {
         console.log('[match_finalizer] no pending tickets – exit');
         return;
     }
+    // Gather unique eventIds from tips[] arrays
     const eventIdSet = new Set();
-    ticketsSnap.docs.forEach(doc => {
-        eventIdSet.add(doc.get('eventId'));
-    });
+    for (const doc of ticketsSnap.docs) {
+        const tips = doc.get('tips') || [];
+        for (const t of tips) {
+            if (t && typeof t.eventId === 'string' && t.eventId.trim()) {
+                eventIdSet.add(t.eventId.trim());
+            }
+        }
+    }
     const eventIds = Array.from(eventIdSet);
     console.log(`[match_finalizer] found ${eventIds.length} unique eventIds`);
     // 2) Fetch scores
@@ -33,23 +43,55 @@ const match_finalizer = async (message) => {
         console.error('[match_finalizer] ResultProvider error', err);
         throw err; // message will be retried / DLQ
     }
-    // 3) Map of completed results
-    const completedMap = new Map();
-    scores.filter(s => s.completed).forEach(s => completedMap.set(s.id, (s.scores?.home || 0) > (s.scores?.away || 0)));
-    // 4) Iterate over tickets and update if completed
+    // 3) Map of results with winner name
+    const resultMap = new Map();
+    scores.forEach(r => {
+        if (!r.completed || !r.scores) {
+            resultMap.set(r.id, { completed: false });
+            return;
+        }
+        const winner = r.scores.home > r.scores.away ? r.home_team : r.away_team;
+        resultMap.set(r.id, { completed: true, winner });
+    });
+    // 4) Evaluate each ticket based on its tips
     const batch = firebase_1.db.batch();
-    ticketsSnap.docs.forEach(doc => {
-        const eventId = doc.get('eventId');
-        if (completedMap.has(eventId)) {
-            const won = completedMap.get(eventId);
-            batch.update(doc.ref, {
-                status: won ? 'won' : 'lost'
-            });
-            if (won) {
-                coinService.credit(doc.get('uid'), doc.get('potentialProfit'), doc.id);
+    for (const snap of ticketsSnap.docs) {
+        const tips = snap.get('tips') || [];
+        if (!tips.length)
+            continue;
+        let hasPending = false;
+        let hasLost = false;
+        for (const t of tips) {
+            const rid = t?.eventId;
+            const pick = (t?.outcome ?? '').trim();
+            if (!rid || !resultMap.has(rid)) {
+                hasPending = true;
+                continue;
+            }
+            const { completed, winner } = resultMap.get(rid);
+            if (!completed || !winner) {
+                hasPending = true;
+                continue;
+            }
+            if (winner !== pick) {
+                hasLost = true;
             }
         }
-    });
+        let newStatus = 'pending';
+        if (hasLost)
+            newStatus = 'lost';
+        else if (!hasPending)
+            newStatus = 'won';
+        if (newStatus !== 'pending') {
+            batch.update(snap.ref, {
+                status: newStatus,
+                updatedAt: firestore_1.FieldValue.serverTimestamp(),
+            });
+            if (newStatus === 'won') {
+                await coinService.credit(snap.get('uid'), snap.get('potentialProfit'), snap.id);
+            }
+        }
+    }
     await batch.commit();
     console.log('[match_finalizer] batch commit done');
 };

--- a/cloud_functions/src/match_finalizer.ts
+++ b/cloud_functions/src/match_finalizer.ts
@@ -1,8 +1,8 @@
-import { PubSub } from '@google-cloud/pubsub';
 import { ResultProvider } from './services/ResultProvider';
 import { CoinService } from './services/CoinService';
 
 import { db } from './lib/firebase';
+import { FieldValue } from 'firebase-admin/firestore';
 const resultProvider = new ResultProvider();
 const coinService = new CoinService();
 
@@ -19,9 +19,12 @@ export const match_finalizer = async (message: PubSubMessage): Promise<void> => 
 
   console.log(`[match_finalizer] received job: ${job}`);
 
-  // 1) Collect pending tickets + related eventIds
-  const ticketsSnap = await db.collection('tickets')
+  // 1) Collect pending tickets across all users via collectionGroup
+  // Tickets are stored under /tickets/{uid}/tickets/{ticketId}
+  const ticketsSnap = await db
+    .collectionGroup('tickets')
     .where('status', '==', 'pending')
+    .limit(200)
     .get();
 
   if (ticketsSnap.empty) {
@@ -29,10 +32,16 @@ export const match_finalizer = async (message: PubSubMessage): Promise<void> => 
     return;
   }
 
+  // Gather unique eventIds from tips[] arrays
   const eventIdSet = new Set<string>();
-  ticketsSnap.docs.forEach(doc => {
-    eventIdSet.add(doc.get('eventId'));
-  });
+  for (const doc of ticketsSnap.docs) {
+    const tips = (doc.get('tips') as any[]) || [];
+    for (const t of tips) {
+      if (t && typeof t.eventId === 'string' && t.eventId.trim()) {
+        eventIdSet.add(t.eventId.trim());
+      }
+    }
+  }
 
   const eventIds = Array.from(eventIdSet);
   console.log(`[match_finalizer] found ${eventIds.length} unique eventIds`);
@@ -46,24 +55,61 @@ export const match_finalizer = async (message: PubSubMessage): Promise<void> => 
     throw err; // message will be retried / DLQ
   }
 
-  // 3) Map of completed results
-  const completedMap = new Map<string, boolean>();
-  scores.filter(s => s.completed).forEach(s => completedMap.set(s.id, (s.scores?.home || 0) > (s.scores?.away || 0)));
+  // 3) Map of results with winner name
+  const resultMap = new Map<string, { completed: boolean; winner?: string }>();
+  scores.forEach(r => {
+    if (!r.completed || !r.scores) {
+      resultMap.set(r.id, { completed: false });
+      return;
+    }
+    const winner = r.scores.home > r.scores.away ? r.home_team : r.away_team;
+    resultMap.set(r.id, { completed: true, winner });
+  });
 
-  // 4) Iterate over tickets and update if completed
+  // 4) Evaluate each ticket based on its tips
   const batch = db.batch();
-  ticketsSnap.docs.forEach(doc => {
-    const eventId = doc.get('eventId');
-    if (completedMap.has(eventId)) {
-      const won = completedMap.get(eventId)!;
-      batch.update(doc.ref, {
-        status: won ? 'won' : 'lost'
-      });
-      if (won) {
-        coinService.credit(doc.get('uid'), doc.get('potentialProfit'), doc.id);
+  for (const snap of ticketsSnap.docs) {
+    const tips = (snap.get('tips') as any[]) || [];
+    if (!tips.length) continue;
+
+    let hasPending = false;
+    let hasLost = false;
+
+    for (const t of tips) {
+      const rid = t?.eventId;
+      const pick = (t?.outcome ?? '').trim();
+      if (!rid || !resultMap.has(rid)) {
+        hasPending = true;
+        continue;
+      }
+      const { completed, winner } = resultMap.get(rid)!;
+      if (!completed || !winner) {
+        hasPending = true;
+        continue;
+      }
+      if (winner !== pick) {
+        hasLost = true;
       }
     }
-  });
+
+    let newStatus: 'pending' | 'won' | 'lost' = 'pending';
+    if (hasLost) newStatus = 'lost';
+    else if (!hasPending) newStatus = 'won';
+
+    if (newStatus !== 'pending') {
+      batch.update(snap.ref, {
+        status: newStatus,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      if (newStatus === 'won') {
+        await coinService.credit(
+          snap.get('uid'),
+          snap.get('potentialProfit'),
+          snap.id,
+        );
+      }
+    }
+  }
 
   await batch.commit();
   console.log('[match_finalizer] batch commit done');

--- a/cloud_functions/src/services/ResultProvider.ts
+++ b/cloud_functions/src/services/ResultProvider.ts
@@ -6,6 +6,8 @@ export interface ScoreResult {
   sport_key: string;
   completed: boolean;
   scores?: { home: number; away: number };
+  home_team?: string;
+  away_team?: string;
 }
 
 /**

--- a/codex_docs/codex_readme_en.md
+++ b/codex_docs/codex_readme_en.md
@@ -70,3 +70,4 @@
 | 2025‑08‑05   | @codex-bot      | TOC refreshed after quota watcher docs                                        |
 | 2025‑08‑05   | @codex-bot      | TOC refreshed after deployment pipeline docs update                           |
 | 2025‑08‑06   | @codex-bot      | TOC refreshed after ticket rules whitelist correction                         |
+| 2025‑08‑07   | @codex-bot      | TOC refreshed after match finalizer evaluation fix                            |

--- a/docs/backend/match_finalizer_en.md
+++ b/docs/backend/match_finalizer_en.md
@@ -1,4 +1,4 @@
-version: "2025-08-11"
+version: "2025-08-07"
 last_updated_by: codex-bot
 depends_on: []
 
@@ -7,9 +7,9 @@ depends_on: []
 Background worker processing `result-check` Pub/Sub messages. Its responsibilities:
 
 1. Decode job type (`kickoff-tracker`, `result-poller`, `final-sweep`).
-2. Query `tickets` collection for pending entries and collect `eventId`s.
-3. Fetch scores via `ResultProvider` and decide win/loss for completed events.
-4. Update ticket `status` and call `CoinService.credit(uid, potentialProfit, ticketId)` for winners.
+2. Query **all** user tickets via `collectionGroup('tickets')` and gather `eventId`s from each ticket's `tips[]` array.
+3. Fetch scores via `ResultProvider`, keeping track of the winning team name for completed events.
+4. Evaluate each ticket: **won** if every tip matches the winner, **lost** if any tip fails, otherwise remain **pending**. Update `status` and call `CoinService.credit(uid, potentialProfit, ticketId)` for winners.
 5. Future step: create `notifications/{uid}` document and send FCM push.
 
 This document covers the TypeScript skeleton; coin transfer logic will be refined in `coin-credit-task`.

--- a/docs/backend/match_finalizer_hu.md
+++ b/docs/backend/match_finalizer_hu.md
@@ -1,4 +1,4 @@
-version: "2025-08-11"
+version: "2025-08-07"
 last_updated_by: codex-bot
 depends_on: []
 
@@ -7,9 +7,9 @@ depends_on: []
 Háttérfolyamat, amely a `result-check` Pub/Sub üzeneteket dolgozza fel. Feladatai:
 
 1. A payloadból kiolvassa a feladat típusát (`kickoff-tracker`, `result-poller`, `final-sweep`).
-2. Lekérdezi a `tickets` kollekció függő tételeit és összegyűjti az `eventId`-ket.
-3. A `ResultProvider` segítségével lekéri az eredményeket és eldönti a nyerés/verés státuszt.
-4. Frissíti a szelvény `status` mezőjét és a nyerteseknek meghívja a `CoinService.credit(uid, potentialProfit, ticketId)` metódust.
+2. A **felhasználók összes szelvényét** a `collectionGroup('tickets')` segítségével kérdezi le, és az `eventId`-ket a `tips[]` tömbből gyűjti.
+3. A `ResultProvider` a győztes csapat nevét is visszaadja, így pontosan eldönthető az eredmény.
+4. Kiértékelés: akkor **nyert** a szelvény, ha minden tipp telitalálat; **vesztett**, ha bármelyik biztosan hibás; egyébként **függő** marad. Frissíti a `status` mezőt és a nyerteseknél meghívja a `CoinService.credit(uid, potentialProfit, ticketId)` metódust.
 5. Következő lépésként `notifications/{uid}` dokumentumot hoz létre és FCM push-t küld.
 
 Ez a dokumentum a TypeScript vázat írja le; a coin tranzakció logika a `coin-credit-task` során finomodik.


### PR DESCRIPTION
## Summary
- handle match finalization across `/tickets/{uid}/tickets/{ticketId}` using collectionGroup
- derive event IDs from ticket `tips[]`, resolve winners and update status/credit
- document new evaluation logic and refresh Codex changelog

## Testing
- `npm ci`
- `npm run build`
- `./scripts/lint_docs.sh` *(warnings: MD033, MD029, etc.)*
- `./scripts/precommit.sh` *(failed: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898f69fbd90832fa98b6973d93e901d