### PR TITLE
fix(router): remove feed redirect from auth gate

### DIFF
--- a/codex_docs/codex_readme_en.md
+++ b/codex_docs/codex_readme_en.md
@@ -71,3 +71,4 @@
 | 2025‑08‑05   | @codex-bot      | TOC refreshed after deployment pipeline docs update                           |
 | 2025‑08‑06   | @codex-bot      | TOC refreshed after ticket rules whitelist correction                         |
 | 2025‑08‑07   | @codex-bot      | TOC refreshed after match finalizer evaluation fix                            |
+| 2025-08-10   | @codex-bot      | TOC refreshed after home default route docs update                            |

--- a/docs/frontend/auth_strategy_en.md
+++ b/docs/frontend/auth_strategy_en.md
@@ -27,7 +27,7 @@ This document outlines the authentication system in **TippmixApp**, including Fi
 - `AuthController` – handles signIn, register, signOut
 - `auth_provider.dart` – exposes `authStateChanges` stream
 - `GoRouter` redirects based on auth state (`redirect:` logic)
-- `AuthGate` – guards private routes and is ignored on Home to let the grid render
+- `AuthGate` – guards private routes and leaves verified users on `/` so the Home grid becomes default
 
 ## 🎯 Codex Rules
 

--- a/docs/frontend/auth_strategy_hu.md
+++ b/docs/frontend/auth_strategy_hu.md
@@ -27,7 +27,7 @@ Ez a dokumentum bemutatja a **TippmixApp** hitelesítési rendszerét: Firebase 
 - `AuthController` – belépés, regisztráció, kijelentkezés logika
 - `auth_provider.dart` – `authStateChanges` stream expozíció
 - `GoRouter` – `redirect:` használat auth állapot alapján
-- `AuthGate` – védi a privát útvonalakat, Home-on placeholderként kezeli a gridhez
+- `AuthGate` – védi a privát útvonalakat; verifikált user esetén a '/' útvonalon hagyja, így a Home csemperács az alapnézet
 
 ## 🎯 Codex szabályok
 

--- a/lib/ui/auth/auth_gate.dart
+++ b/lib/ui/auth/auth_gate.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import '../../screens/auth/login_screen.dart';
 // HomeScreen-import kivezetve – a ShellRoute hozza be
 import '../../providers/auth_provider.dart';
@@ -22,10 +21,8 @@ class AuthGate extends ConsumerWidget {
     if (!notifier.isEmailVerified) {
       return const EmailNotVerifiedScreen();
     }
-    // A ShellRoute már tartalmazza a Home-héjat; itt csak átirányítunk
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (context.mounted) context.go('/feed');
-    });
+    // Bejelentkezett és verifikált felhasználó → maradunk a '/' útvonalon,
+    // a ShellRoute + HomeScreen héj megjeleníti a fő (csempés) kezdőképernyőt.
     return const SizedBox.shrink();
   }
 }

--- a/test/navigation/home_default_route_test.dart
+++ b/test/navigation/home_default_route_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tippmixapp/l10n/app_localizations.dart';
+import 'package:tippmixapp/router.dart';
+import 'package:tippmixapp/providers/auth_provider.dart';
+import 'package:tippmixapp/models/auth_state.dart';
+import 'package:tippmixapp/models/user.dart';
+import 'package:tippmixapp/controllers/splash_controller.dart';
+import 'package:tippmixapp/routes/app_route.dart';
+import 'package:tippmixapp/services/auth_service.dart';
+
+class _FakeAuthService implements AuthService {
+  final _controller = StreamController<User?>.broadcast();
+  User? _current = User(id: 'u1', email: 'u@x.com', displayName: 'U');
+
+  _FakeAuthService() {
+    _controller.add(_current);
+  }
+
+  @override
+  Stream<User?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<User?> signInWithEmail(String email, String password) async => null;
+
+  @override
+  Future<User?> registerWithEmail(String email, String password) async => null;
+
+  @override
+  Future<void> signOut() async {
+    _current = null;
+    _controller.add(null);
+  }
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  bool get isEmailVerified => true;
+
+  @override
+  User? get currentUser => _current;
+
+  @override
+  Future<bool> validateEmailUnique(String email) async => true;
+
+  @override
+  Future<bool> validateNicknameUnique(String nickname) async => true;
+
+  @override
+  Future<User?> signInWithGoogle() async => null;
+
+  @override
+  Future<User?> signInWithApple() async => null;
+
+  @override
+  Future<User?> signInWithFacebook() async => null;
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
+
+  @override
+  Future<bool> pollEmailVerification({
+    Duration timeout = const Duration(minutes: 3),
+    Duration interval = const Duration(seconds: 5),
+  }) async => true;
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier() : super(_FakeAuthService()) {
+    state = AuthState(
+      user: User(id: 'u1', email: 'u@x.com', displayName: 'U'),
+    );
+  }
+}
+
+class _FakeSplashController extends StateNotifier<AsyncValue<AppRoute>>
+    implements SplashController {
+  _FakeSplashController() : super(const AsyncLoading()) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      state = const AsyncData(AppRoute.home);
+    });
+  }
+}
+
+void main() {
+  testWidgets('Verified user → stays on / and sees Home content', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier()),
+        splashControllerProvider.overrideWith((ref) => _FakeSplashController()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // A gyökér útvonal maradjon aktív
+    expect(router.routerDelegate.currentConfiguration.fullPath, '/');
+
+    // A HomeScreen jellegzetes elemei megjelennek (pl. Scaffold)
+    expect(find.byType(Scaffold), findsOneWidget);
+    // Nem a FeedScreen a kezdő
+    expect(find.text('Feed'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- keep verified users on '/' by removing feed redirect in `AuthGate`
- document home-as-default behavior in auth strategy docs (EN/HU) and update Codex changelog
- add widget test verifying `/` remains active for verified user

## Testing
- `./flutter/bin/flutter analyze lib test`
- `./flutter/bin/flutter test test/navigation/home_default_route_test.dart`
- `./flutter/bin/flutter test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68991f15e3e0832f82528df1f40145cf