### PR TITLE
fix(events): add bet slip integration and filter expired

### DIFF
--- a/lib/screens/events_screen.dart
+++ b/lib/screens/events_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tippmixapp/l10n/app_localizations.dart';
 
 import '../providers/odds_api_provider.dart';
-import '../providers/bet_slip_provider.dart'; // feltételezzük, hogy van ilyen
+import '../providers/bet_slip_provider.dart';
+import '../utils/events_filter.dart';
+import '../models/tip_model.dart';
 import 'package:go_router/go_router.dart';
 import '../widgets/event_bet_card.dart';
 
@@ -52,7 +54,8 @@ class _EventsScreenState extends ConsumerState<EventsScreen> {
         } else if (oddsState is OddsApiData) {
           final events = oddsState.events;
           final quotaWarn = oddsState.quotaWarning;
-          if (events.isEmpty) {
+          final filtered = filterActiveEvents(events);
+          if (filtered.isEmpty) {
             return Center(child: Text(loc.events_screen_no_events));
           }
           return Column(
@@ -85,9 +88,9 @@ class _EventsScreenState extends ConsumerState<EventsScreen> {
                 ),
               Expanded(
                 child: ListView.builder(
-                  itemCount: events.length,
+                  itemCount: filtered.length,
                   itemBuilder: (context, index) {
-                    final event = events[index];
+                    final event = filtered[index];
                     // Kiváltjuk a belső kártyát az új, újrahasznosítható EventBetCard-dal
                     final bookmaker = event.bookmakers.isNotEmpty
                         ? event.bookmakers.first
@@ -104,28 +107,76 @@ class _EventsScreenState extends ConsumerState<EventsScreen> {
                       event: event,
                       h2hMarket: market,
                       onTapHome: (outcome) {
+                        final tip = TipModel(
+                          eventId: event.id,
+                          eventName: '${event.homeTeam} – ${event.awayTeam}',
+                          startTime: event.commenceTime,
+                          sportKey: event.sportKey,
+                          bookmaker: bookmaker?.key ?? 'unknown',
+                          marketKey: market?.key ?? 'h2h',
+                          outcome: outcome.name,
+                          odds: outcome.price,
+                        );
+                        final added = ref
+                            .read(betSlipProvider.notifier)
+                            .addTip(tip);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
+                            duration: const Duration(seconds: 2),
                             content: Text(
-                              '${outcome.name} @ ${outcome.price.toStringAsFixed(2)}',
+                              added
+                                  ? loc.events_screen_tip_added
+                                  : loc.events_screen_tip_duplicate,
                             ),
                           ),
                         );
                       },
                       onTapDraw: (outcome) {
+                        final tip = TipModel(
+                          eventId: event.id,
+                          eventName: '${event.homeTeam} – ${event.awayTeam}',
+                          startTime: event.commenceTime,
+                          sportKey: event.sportKey,
+                          bookmaker: bookmaker?.key ?? 'unknown',
+                          marketKey: market?.key ?? 'h2h',
+                          outcome: outcome.name,
+                          odds: outcome.price,
+                        );
+                        final added = ref
+                            .read(betSlipProvider.notifier)
+                            .addTip(tip);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
+                            duration: const Duration(seconds: 2),
                             content: Text(
-                              'X @ ${outcome.price.toStringAsFixed(2)}',
+                              added
+                                  ? loc.events_screen_tip_added
+                                  : loc.events_screen_tip_duplicate,
                             ),
                           ),
                         );
                       },
                       onTapAway: (outcome) {
+                        final tip = TipModel(
+                          eventId: event.id,
+                          eventName: '${event.homeTeam} – ${event.awayTeam}',
+                          startTime: event.commenceTime,
+                          sportKey: event.sportKey,
+                          bookmaker: bookmaker?.key ?? 'unknown',
+                          marketKey: market?.key ?? 'h2h',
+                          outcome: outcome.name,
+                          odds: outcome.price,
+                        );
+                        final added = ref
+                            .read(betSlipProvider.notifier)
+                            .addTip(tip);
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
+                            duration: const Duration(seconds: 2),
                             content: Text(
-                              '${outcome.name} @ ${outcome.price.toStringAsFixed(2)}',
+                              added
+                                  ? loc.events_screen_tip_added
+                                  : loc.events_screen_tip_duplicate,
                             ),
                           ),
                         );

--- a/lib/utils/events_filter.dart
+++ b/lib/utils/events_filter.dart
@@ -1,0 +1,10 @@
+import '../models/odds_event.dart';
+
+/// Csak a még fogadható (jövőbeli kezdésű) eseményeket adja vissza.
+List<OddsEvent> filterActiveEvents(
+  List<OddsEvent> events, {
+  Duration grace = const Duration(minutes: 2),
+}) {
+  final cutoff = DateTime.now().add(grace);
+  return events.where((e) => e.commenceTime.isAfter(cutoff)).toList();
+}

--- a/test/events_screen_test.dart
+++ b/test/events_screen_test.dart
@@ -43,7 +43,7 @@ void main() {
       sportTitle: 'Soccer',
       homeTeam: 'Team A',
       awayTeam: 'Team B',
-      commenceTime: DateTime.parse('2024-01-01T12:00:00Z'),
+      commenceTime: DateTime.now().add(const Duration(hours: 1)),
       bookmakers: [
         OddsBookmaker(
           key: 'b',

--- a/test/providers/bet_slip_provider_add_tip_test.dart
+++ b/test/providers/bet_slip_provider_add_tip_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tippmixapp/providers/bet_slip_provider.dart';
+import 'package:tippmixapp/models/tip_model.dart';
+
+TipModel tip(String eventId, String outcome) => TipModel(
+  eventId: eventId,
+  eventName: 'A – B',
+  startTime: DateTime.now().add(const Duration(hours: 1)),
+  sportKey: 'soccer',
+  bookmaker: 'bk',
+  marketKey: 'h2h',
+  outcome: outcome,
+  odds: 1.5,
+);
+
+void main() {
+  test('addTip adds once and prevents duplicates', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(betSlipProvider.notifier);
+    expect(container.read(betSlipProvider).tips, isEmpty);
+
+    final ok1 = notifier.addTip(tip('e1', 'home'));
+    expect(ok1, isTrue);
+    expect(container.read(betSlipProvider).tips.length, 1);
+
+    final dup = notifier.addTip(tip('e1', 'home'));
+    expect(dup, isFalse);
+    expect(container.read(betSlipProvider).tips.length, 1);
+  });
+}

--- a/test/utils/events_filter_test.dart
+++ b/test/utils/events_filter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tippmixapp/utils/events_filter.dart';
+import 'package:tippmixapp/models/odds_event.dart';
+import 'package:tippmixapp/models/odds_bookmaker.dart';
+
+OddsEvent makeEvent(String id, DateTime when) => OddsEvent(
+  id: id,
+  sportKey: 'soccer',
+  sportTitle: 'Soccer',
+  homeTeam: 'A',
+  awayTeam: 'B',
+  commenceTime: when,
+  bookmakers: const <OddsBookmaker>[],
+);
+
+void main() {
+  test('filterActiveEvents keeps only future events (with 2m grace)', () {
+    final now = DateTime.now();
+    final items = [
+      makeEvent('past', now.subtract(const Duration(minutes: 1))),
+      makeEvent('soon', now.add(const Duration(minutes: 1, seconds: 30))),
+      makeEvent('future', now.add(const Duration(minutes: 5))),
+    ];
+    final res = filterActiveEvents(items);
+    expect(res.map((e) => e.id).toList(), ['future']);
+  });
+}


### PR DESCRIPTION
## Summary
- filter expired events on Events screen and link FAB tips
- add bet slip integration with TipModel
- cover new utils and provider behavior with tests

## Testing
- `./flutter/bin/flutter analyze lib test`
- `./flutter/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689a576e0164832fb2cccee46ad760a5