### PR TITLE
docs: document tickets schema and add rules overlay

### DIFF
--- a/canvases/tickets_schema_and_rules.md
+++ b/canvases/tickets_schema_and_rules.md
@@ -10,18 +10,18 @@ Definiáljuk a `tickets` kollekció sémáját és indexeit, hozzunk létre **kl
 
 ## Feladatok
 
-* [ ] **Séma doksi**: `docs/backend/firestore_tickets_schema.md` – mezők, típusok, példák, státuszgraf
-* [ ] **Biztonsági szabály‑overlay**: `security/tickets.rules` – csak saját ticket **olvasható**, **írás tiltott** (kivéve opcionális `tickets_drafts` kliens‑draftok)
-* [ ] **Indexek**: `firestore.indexes.json` – `tickets` by `(userId, createdAt desc)` és `(status, createdAt desc)`
-* [ ] **Smoke ellenőrzés**: `flutter analyze` + Functions build/test érintetlenül zöld (nem nyúlunk aktív rule‑fájlhoz)
+* [x] **Séma doksi**: `docs/backend/firestore_tickets_schema.md` – mezők, típusok, példák, státuszgraf
+* [x] **Biztonsági szabály‑overlay**: `security/tickets.rules` – csak saját ticket **olvasható**, **írás tiltott** (kivéve opcionális `tickets_drafts` kliens‑draftok)
+* [x] **Indexek**: `firestore.indexes.json` – `tickets` by `(userId, createdAt desc)` és `(status, createdAt desc)`
+* [x] **Smoke ellenőrzés**: `flutter analyze` + Functions build/test érintetlenül zöld (nem nyúlunk aktív rule‑fájlhoz)
 
 ## Acceptance Criteria / Done Definition
 
-* [ ] A repo tartalmazza a `docs/backend/firestore_tickets_schema.md` fájlt részletes meződefiníciókkal és mintákkal
-* [ ] Létezik egy **izolált** szabályfájl: `security/tickets.rules` a `tickets`/**`tickets_drafts`** kollekciókra
-* [ ] `firestore.indexes.json` tartalmazza a fenti két kompozit indexet
-* [ ] A meglévő `firestore.rules` **nem** módosul ebben a lépésben; működő funkciók nem sérülnek
-* [ ] `flutter analyze` és a Cloud Functions build/test zöld
+* [x] A repo tartalmazza a `docs/backend/firestore_tickets_schema.md` fájlt részletes meződefiníciókkal és mintákkal
+* [x] Létezik egy **izolált** szabályfájl: `security/tickets.rules` a `tickets`/**`tickets_drafts`** kollekciókra
+* [x] `firestore.indexes.json` tartalmazza a fenti két kompozit indexet
+* [x] A meglévő `firestore.rules` **nem** módosul ebben a lépésben; működő funkciók nem sérülnek
+* [x] `flutter analyze` és a Cloud Functions build/test zöld
 
 ## Hivatkozások
 

--- a/docs/backend/firestore_tickets_schema.md
+++ b/docs/backend/firestore_tickets_schema.md
@@ -1,0 +1,54 @@
+# Firestore – `tickets` séma (provider‑független)
+
+## Gyors áttekintés
+Kollekció: `tickets/{ticketId}`
+
+| Mező | Típus | Kötelező | Megjegyzés |
+|---|---|---|---|
+| userId | string | igen | Ticket tulajdonosa |
+| createdAt | timestamp | igen | Szerver idő |
+| status | string | igen | `pending|won|lost|void` |
+| stake | number | igen | TippCoin tét |
+| payout | number | igen | Záráskor számolt |
+| tips | array<Tip> | igen | Lásd alább |
+| processedAt | timestamp | nem | Finalizer állítja |
+
+**Tip**
+- fixtureId: string (API‑Football fixture ID)
+- leagueId: string
+- teamHomeId: string
+- teamAwayId: string
+- market: string (pl. `1X2|OU|BTTS|AH`)
+- selection: string (pl. `HOME|DRAW|AWAY`, `OVER_2_5`)
+- oddsSnapshot: number (kötelező)
+- kickoff: timestamp
+
+## Példadokumentum
+```json
+{
+  "userId": "uid_123",
+  "createdAt": {"_seconds": 1700000000, "_nanoseconds": 0},
+  "status": "pending",
+  "stake": 100,
+  "payout": 0,
+  "tips": [
+    {
+      "fixtureId": "120934",
+      "leagueId": "39",
+      "teamHomeId": "40",
+      "teamAwayId": "50",
+      "market": "1X2",
+      "selection": "HOME",
+      "oddsSnapshot": 1.85,
+      "kickoff": {"_seconds": 1700003600, "_nanoseconds": 0}
+    }
+  ]
+}
+```
+
+## Indexek
+- `tickets`: (userId ASC, createdAt DESC)
+- `tickets`: (status ASC, createdAt DESC)
+
+## Megjegyzés
+- A `tickets` írását Cloud Functions végzi Admin SDK‑val (rules megkerülve), ezért a kliens‑write tiltása biztonságos.

--- a/docs/backend/firestore_tickets_schema_en.md
+++ b/docs/backend/firestore_tickets_schema_en.md
@@ -1,0 +1,54 @@
+# Firestore – `tickets` schema (provider‑agnostic)
+
+## Quick overview
+Collection: `tickets/{ticketId}`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| userId | string | yes | Ticket owner |
+| createdAt | timestamp | yes | Server time |
+| status | string | yes | `pending|won|lost|void` |
+| stake | number | yes | TippCoin stake |
+| payout | number | yes | Calculated at closure |
+| tips | array<Tip> | yes | See below |
+| processedAt | timestamp | no | Set by finalizer |
+
+**Tip**
+- fixtureId: string (API‑Football fixture ID)
+- leagueId: string
+- teamHomeId: string
+- teamAwayId: string
+- market: string (e.g. `1X2|OU|BTTS|AH`)
+- selection: string (e.g. `HOME|DRAW|AWAY`, `OVER_2_5`)
+- oddsSnapshot: number (required)
+- kickoff: timestamp
+
+## Sample document
+```json
+{
+  "userId": "uid_123",
+  "createdAt": {"_seconds": 1700000000, "_nanoseconds": 0},
+  "status": "pending",
+  "stake": 100,
+  "payout": 0,
+  "tips": [
+    {
+      "fixtureId": "120934",
+      "leagueId": "39",
+      "teamHomeId": "40",
+      "teamAwayId": "50",
+      "market": "1X2",
+      "selection": "HOME",
+      "oddsSnapshot": 1.85,
+      "kickoff": {"_seconds": 1700003600, "_nanoseconds": 0}
+    }
+  ]
+}
+```
+
+## Indexes
+- `tickets`: (userId ASC, createdAt DESC)
+- `tickets`: (status ASC, createdAt DESC)
+
+## Notes
+- Cloud Functions write `tickets` via the Admin SDK (bypassing rules), so denying client writes is safe.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,33 @@
+{
+  "fieldOverrides": [],
+  "indexes": [
+    {
+      "collectionGroup": "tickets",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
+    },
+    {
+      "collectionGroup": "tickets",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
+    }
+  ]
+}

--- a/security/tickets.rules
+++ b/security/tickets.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() { return request.auth != null; }
+    function isOwner(uid) { return isSignedIn() && request.auth.uid == uid; }
+
+    // Final tickets: client read-only
+    match /tickets/{ticketId} {
+      allow read: if isOwner(resource.data.userId);
+      allow create, update, delete: if false; // Only via Admin SDK (Cloud Functions)
+    }
+
+    // Optional client drafts flow
+    match /tickets_drafts/{draftId} {
+      allow read, create, update, delete: if isSignedIn() &&
+        request.resource.data.userId == request.auth.uid;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document Firestore `tickets` schema in EN and HU
- add read-only security rules overlay for `tickets` and optional drafts
- define composite indexes for common ticket queries

## Testing
- `./flutter/bin/flutter analyze lib test`
- `./flutter/bin/flutter test --coverage`
- `cd cloud_functions && npm ci && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb0e03444832f9e250590a7fec2a6