### PR TITLE
Ensure odds parsing and home screen header test coverage

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -142,13 +142,20 @@ class HomeScreen extends ConsumerWidget {
     final user = authState.user; // lehet null vendégnél
     final stats = ref.watch(userStatsProvider).asData?.value;
     final showHeader = showStats || _isRootRoute(context);
+    Widget? header;
+    if (showHeader) {
+      if (stats != null || user != null) {
+        header = UserStatsHeader(
+          key: const ValueKey('user-stats-header'),
+          stats: stats,
+        );
+      } else {
+        header = const HomeGuestCtaTile();
+      }
+    }
     return Column(
       children: [
-        // Fejléc a képernyő tetején: vendég → CTA, bejelentkezett → profil header
-        if (showHeader)
-          (user == null
-              ? const HomeGuestCtaTile()
-              : UserStatsHeader(stats: stats)),
+        if (header != null) header,
         Expanded(
           child: GridView.count(
             padding: const EdgeInsets.all(16),

--- a/lib/services/market_mapping.dart
+++ b/lib/services/market_mapping.dart
@@ -8,7 +8,8 @@ class MarketMapping {
   static const String asianHandicap = 'ah';
 
   static String? fromApiFootball(String key) {
-    switch (key.toLowerCase()) {
+    final normalized = key.trim().toLowerCase();
+    switch (normalized) {
       case '1x2':
       case 'h2h':
       case 'match winner':
@@ -85,13 +86,13 @@ class MarketMapping {
               final price = double.tryParse(oddStr.replaceAll(',', '.'));
               if (price == null) continue;
               if (val == 'home' || val == '1' || (hn != null && valn == hn)) {
-                home = OddsOutcome(name: 'Home', price: price);
+                home = OddsOutcome(name: homeName ?? 'Home', price: price);
               } else if (val == 'draw' || val == 'x') {
                 draw = OddsOutcome(name: 'Draw', price: price);
               } else if (val == 'away' ||
                   val == '2' ||
                   (an != null && valn == an)) {
-                away = OddsOutcome(name: 'Away', price: price);
+                away = OddsOutcome(name: awayName ?? 'Away', price: price);
               }
             }
             final outs = [
@@ -135,13 +136,13 @@ class MarketMapping {
             final price = double.tryParse(oddStr.replaceAll(',', '.'));
             if (price == null) continue;
             if (val == 'home' || val == '1' || (hn != null && valn == hn)) {
-              home = OddsOutcome(name: 'Home', price: price);
+              home = OddsOutcome(name: homeName ?? 'Home', price: price);
             } else if (val == 'draw' || val == 'x') {
               draw = OddsOutcome(name: 'Draw', price: price);
             } else if (val == 'away' ||
                 val == '2' ||
                 (an != null && valn == an)) {
-              away = OddsOutcome(name: 'Away', price: price);
+              away = OddsOutcome(name: awayName ?? 'Away', price: price);
             }
           }
           final outs = [

--- a/lib/widgets/event_bet_card.dart
+++ b/lib/widgets/event_bet_card.dart
@@ -41,6 +41,7 @@ class EventBetCard extends StatefulWidget {
 
 class _EventBetCardState extends State<EventBetCard> {
   String? _selected; // 'home', 'draw', 'away'
+  Future<OddsMarket?>? _h2hFuture;
 
   @override
   void initState() {
@@ -151,14 +152,15 @@ class _EventBetCardState extends State<EventBetCard> {
                       RegExp(r'\d+').firstMatch(event.id)?.group(0) ?? '',
                     ) ??
                     0;
+                _h2hFuture ??= widget.apiService.getH2HForFixture(
+                  fid,
+                  season: event.season ?? event.commenceTime.year,
+                  homeName: event.homeTeam,
+                  awayName: event.awayTeam,
+                );
                 return FutureBuilder<OddsMarket?>(
                   key: ValueKey('markets-${event.id}'),
-                  future: widget.apiService.getH2HForFixture(
-                    fid,
-                    season: event.season ?? event.commenceTime.year,
-                    homeName: event.homeTeam,
-                    awayName: event.awayTeam,
-                  ),
+                  future: _h2hFuture,
                   builder: (context, snapshot) {
                     if (snapshot.connectionState == ConnectionState.waiting) {
                       return _loadingMarkets();
@@ -185,6 +187,7 @@ class _EventBetCardState extends State<EventBetCard> {
               alignment: Alignment.centerLeft,
               child: Text(
                 loc.updated_time_ago(_formatYMDHM(ra)),
+                key: ValueKey('updated-${event.id}'),
                 style: Theme.of(context).textTheme.labelSmall,
               ),
             ),
@@ -242,6 +245,7 @@ class _EventBetCardState extends State<EventBetCard> {
     OddsOutcome? away,
   ) {
     return Row(
+      key: const ValueKey('h2h-row'),
       children: [
         Expanded(
           child: home != null
@@ -341,6 +345,7 @@ class _EventBetCardState extends State<EventBetCard> {
       children: [
         Text(
           l.starts_at(_formatYMDHM(e.commenceTime)),
+          key: ValueKey('kickoff-${e.id}'),
           textAlign: TextAlign.left,
           style: Theme.of(
             context,

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -160,7 +160,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // ✅ Assertions
-    expect(find.byType(UserStatsHeader), findsOneWidget);
+    expect(find.byKey(const ValueKey('user-stats-header')), findsOneWidget);
     expect(find.text('Daily Bonus'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- parse API-Football odds into H2H market and map BTTS key
- map match winner outcomes to team names and trim market keys
- avoid redundant H2H fetches in EventBetCard and add stable keys
- always render user stats header on home screen and key tests

## Testing
- `flutter test --coverage test/services/api_football_service_test.dart`
- `flutter test --coverage test/services/api_football_mapping_test.dart`
- `flutter test --coverage test/widgets/event_bet_card_h2h_render_test.dart`
- `flutter test --coverage test/screens/home_screen_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a7a619ffc0832f955aacbff38e52d7