### PR TITLE
feat(functions): add gen2 options with secret binding

### DIFF
--- a/cloud_functions/index.ts
+++ b/cloud_functions/index.ts
@@ -1,4 +1,6 @@
+import { setGlobalOptions } from 'firebase-functions/v2';
 import { onMessagePublished } from 'firebase-functions/v2/pubsub';
+import { defineSecret } from 'firebase-functions/params';
 import { match_finalizer as matchFinalizerHandler } from './src/match_finalizer';
 
 export { onUserCreate, coin_trx } from './coin_trx.logic';
@@ -6,8 +8,14 @@ export { log_coin } from './log_coin';
 export { onFriendRequestAccepted } from './friend_request';
 export { daily_bonus } from './src/daily_bonus';
 
+// Global options for all v2 functions
+setGlobalOptions({ region: 'europe-central2' });
+
+// Secret from Secret Manager (Console → Secret Manager → API_FOOTBALL_KEY)
+export const API_FOOTBALL_KEY = defineSecret('API_FOOTBALL_KEY');
+
 // Gen2 Pub/Sub trigger (topic: result-check, region via global options)
-export const match_finalizer = onMessagePublished('result-check', async (event) => {
+export const match_finalizer = onMessagePublished({ topic: 'result-check', secrets: [API_FOOTBALL_KEY] }, async (event) => {
   const msg = {
     data: event.data.message?.data,
     attributes: event.data.message?.attributes as { [key: string]: string } | undefined,

--- a/cloud_functions/src/daily_bonus.ts
+++ b/cloud_functions/src/daily_bonus.ts
@@ -1,12 +1,14 @@
-import * as functions from 'firebase-functions';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { setGlobalOptions } from 'firebase-functions/v2';
 import { db } from './lib/firebase';
 import { CoinService } from './services/CoinService';
 
-export const daily_bonus = functions
-  .region('europe-central2')
-  .pubsub.schedule('5 0 * * *')
-  .timeZone('Europe/Budapest')
-  .onRun(async () => {
+// region default for v2
+setGlobalOptions({ region: 'europe-central2' });
+
+export const daily_bonus = onSchedule(
+  { schedule: '5 0 * * *', timeZone: 'Europe/Budapest' },
+  async () => {
     const usersSnap = await db.collection('users').get();
     const bonusCoins = 50;
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
@@ -16,4 +18,5 @@ export const daily_bonus = functions
       const uid = doc.id;
       await new CoinService().credit(uid, bonusCoins, refId);
     }
-  });
+  }
+);

--- a/docs/backend/api_football_key_notes.md
+++ b/docs/backend/api_football_key_notes.md
@@ -1,6 +1,7 @@
 # API_FOOTBALL_KEY beállítása
 
 - GitHub Secrets: `API_FOOTBALL_KEY`
-- Firebase Functions config: `firebase functions:config:set apifootball.key="<SECRET>"`
-- A kulcs a Cloud Functions környezetben `process.env.API_FOOTBALL_KEY` változóba kerül (deploy pipeline tölti be).
+- Google Secret Manager: hozz létre `API_FOOTBALL_KEY` titkot
+- Adj **Secret Manager Secret Accessor** jogosultságot a Functions runtime service accountnak
+- A kulcsot kódban a `defineSecret('API_FOOTBALL_KEY')` köti be, így futásidőben a `process.env.API_FOOTBALL_KEY` változóban érhető el
 - Ne logold és ne írd ki a kulcsot semmilyen naplóba.

--- a/docs/backend/api_football_key_notes_en.md
+++ b/docs/backend/api_football_key_notes_en.md
@@ -1,6 +1,7 @@
 # API_FOOTBALL_KEY setup
 
 - GitHub Secrets: `API_FOOTBALL_KEY`
-- Firebase Functions config: `firebase functions:config:set apifootball.key="<SECRET>"`
-- The key becomes available in the Cloud Functions environment as `process.env.API_FOOTBALL_KEY` (loaded by the deploy pipeline).
+- Google Secret Manager: create secret `API_FOOTBALL_KEY`
+- Grant the Functions runtime service account the `roles/secretmanager.secretAccessor` role
+- The key is bound in code via `defineSecret('API_FOOTBALL_KEY')` and becomes available at runtime as `process.env.API_FOOTBALL_KEY`
 - Do not log or print the key in any logs.

--- a/docs/backend/match_finalizer_en.md
+++ b/docs/backend/match_finalizer_en.md
@@ -20,3 +20,4 @@ This document covers the TypeScript skeleton with atomic payout handling.
 
 **Runtime**: Node.js 20 on 2nd gen Cloud Functions.
 Uses the firebase-functions v2 `onMessagePublished` trigger, avoiding the legacy `GCLOUD_PROJECT` requirement.
+`API_FOOTBALL_KEY` is injected from Secret Manager via `defineSecret` and exposed as `process.env.API_FOOTBALL_KEY`.

--- a/docs/backend/match_finalizer_hu.md
+++ b/docs/backend/match_finalizer_hu.md
@@ -19,3 +19,4 @@ Háttérfolyamat, amely a `result-check` Pub/Sub üzeneteket dolgozza fel. Felad
 Ez a dokumentum a TypeScript vázat írja le, immár atomikus kifizetéssel.
 **Futtatókörnyezet**: Node.js 20, 2. generációs Cloud Functions.
 A `firebase-functions` v2 `onMessagePublished` triggert használja, így nem szükséges a régi `GCLOUD_PROJECT` környezeti változó.
+Az `API_FOOTBALL_KEY` titok a Secret Managerből `defineSecret` segítségével kerül be és `process.env.API_FOOTBALL_KEY` néven érhető el.


### PR DESCRIPTION
## Summary
- migrate Cloud Functions to use v2 global options and Secret Manager bound API_FOOTBALL_KEY
- switch daily_bonus scheduler to firebase-functions v2 with region defaults
- document Secret Manager setup for API_FOOTBALL_KEY and match_finalizer

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest')*
- `npm test --silent || true` *(fails: jest not found)*
- `./scripts/lint_docs.sh`
- `./scripts/precommit.sh` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8457b3c832f911d663b4f22811a