### PR TITLE
fix: harden match_finalizer cloudevent wrapper

### DIFF
--- a/cloud_functions/package.json
+++ b/cloud_functions/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": "20"
+    "node": ">=20"
   },
   "main": "lib/index.js",
   "name": "cloud_functions",

--- a/codex_docs/codex_readme_en.md
+++ b/codex_docs/codex_readme_en.md
@@ -119,3 +119,4 @@
 | 2025-10-02   | @codex-bot      | TOC refreshed after Firestore functions ops docs update                        |
 | 2025-10-03   | @codex-bot      | TOC refreshed after finalizer hardening docs update                            |
 | 2025-10-05   | @codex-bot      | TOC refreshed after CI deploy MODE fix docs update                              |
+| 2025-10-15   | @codex-bot      | TOC refreshed after match finalizer CloudEvent docs update                      |

--- a/docs/backend/match_finalizer_en.md
+++ b/docs/backend/match_finalizer_en.md
@@ -1,4 +1,4 @@
-version: "2025-10-10"
+version: "2025-10-15"
 last_updated_by: codex-bot
 depends_on: []
 
@@ -21,6 +21,6 @@ This document covers the TypeScript skeleton with atomic payout handling.
 
 **Runtime**: Node.js 20 on 2nd gen Cloud Functions.
 Uses the firebase-functions v2 `onMessagePublished` trigger, avoiding the legacy `GCLOUD_PROJECT` requirement.
-The entry point receives a typed `CloudEvent<MessagePublishedData>` and logs `hasMsg` and attribute keys before delegating; empty events are skipped with a `match_finalizer.no_message` warning.
+The entry point receives a typed `CloudEvent<MessagePublishedData>` and logs `hasMsg`, `hasData` and attribute keys before delegating; empty events are skipped with a `match_finalizer.no_message` warning.
 `API_FOOTBALL_KEY` is injected from Secret Manager via `defineSecret` and exposed as `process.env.API_FOOTBALL_KEY`.
 `retry: true` is enabled and structured logs are emitted via `firebase-functions/logger`.

--- a/docs/backend/match_finalizer_hu.md
+++ b/docs/backend/match_finalizer_hu.md
@@ -1,4 +1,4 @@
-version: "2025-10-10"
+version: "2025-10-15"
 last_updated_by: codex-bot
 depends_on: []
 
@@ -20,6 +20,6 @@ Háttérfolyamat, amely a `result-check` Pub/Sub üzeneteket dolgozza fel. Felad
 Ez a dokumentum a TypeScript vázat írja le, immár atomikus kifizetéssel.
 **Futtatókörnyezet**: Node.js 20, 2. generációs Cloud Functions.
 A `firebase-functions` v2 `onMessagePublished` triggert használja, így nem szükséges a régi `GCLOUD_PROJECT` környezeti változó.
-A belépési pont típusos `CloudEvent<MessagePublishedData>` eseményt kap, `hasMsg` és attribútumkulcsok naplózásával. Üres esemény esetén `match_finalizer.no_message` figyelmeztetést ír és visszatér.
+A belépési pont típusos `CloudEvent<MessagePublishedData>` eseményt kap, `hasMsg`, `hasData` és attribútumkulcsok naplózásával. Üres esemény esetén `match_finalizer.no_message` figyelmeztetést ír és visszatér.
 Az `API_FOOTBALL_KEY` titok a Secret Managerből `defineSecret` segítségével kerül be és `process.env.API_FOOTBALL_KEY` néven érhető el.
 `retry: true` engedélyezve van, és strukturált logolást használ a `firebase-functions/logger`.


### PR DESCRIPTION
## Summary
- enforce Node >=20 for cloud functions
- document match_finalizer CloudEvent wrapper
- refresh Codex docs changelog

## Testing
- `npm run build` *(fails: Cannot find namespace 'FirebaseFirestore')*
- `gcloud functions deploy match_finalizer --gen2 --region=europe-central2 --runtime=nodejs20 --trigger-topic=result-check --entry-point=match_finalizer --project=tippmix-dev --quiet` *(fails: command not found)*
- `gcloud pubsub topics publish projects/tippmix-dev/topics/result-check --message='{"job":"final-sweep"}' --project=tippmix-dev` *(fails: command not found)*
- `gcloud functions logs read match_finalizer --gen2 --region=europe-central2 --limit=50` *(fails: command not found)*
- `flutter analyze lib test integration_test bin tool` *(fails: path does not exist)*
- `flutter test --coverage`
- `npm test` *(fails: jest: not found)*
- `./scripts/lint_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aac0796b80832f8c021da09e10d965