### PR TITLE
feat(bets): clear slip and route with names

### DIFF
--- a/docs/bet_h2h_fixed_labels_and_ticket_clear.md
+++ b/docs/bet_h2h_fixed_labels_and_ticket_clear.md
@@ -1,8 +1,8 @@
-version: "2025-09-20"
+version: "2025-10-21"
 last_updated_by: codex-bot
 depends_on: []
 
 # Bet H2H fixed labels and ticket clear
 
 - H2H buttons display fixed localized labels (`home_short`, `draw_short`, `away_short`).
-- On successful ticket submit the `betSlipProvider` is cleared, a SnackBar shows `ticket_submit_success`, and navigation pops back to the bets screen.
+- On successful ticket submit the `betSlipProvider` is cleared, a SnackBar shows `ticket_submit_success`, and navigation returns to the bets screen via `context.goNamed(AppRoute.bets.name)`.

--- a/docs/bet_h2h_fixed_labels_and_ticket_clear_hu.md
+++ b/docs/bet_h2h_fixed_labels_and_ticket_clear_hu.md
@@ -1,8 +1,8 @@
-version: "2025-09-20"
+version: "2025-10-21"
 last_updated_by: codex-bot
 depends_on: []
 
 # Fogadási oldal – H2H fix címkék és szelvény ürítés
 
 - A H2H gombok fix, lokalizált feliratot kapnak (`home_short`, `draw_short`, `away_short`).
-- Sikeres szelvénybeküldés után kiürül a `betSlipProvider`, a SnackBar üzenete: „Szelvény beküldve”, majd visszanavigál a fogadások képernyőre.
+- Sikeres szelvénybeküldés után kiürül a `betSlipProvider`, a SnackBar üzenete: „Szelvény beküldve”, majd név alapján (`context.goNamed(AppRoute.bets.name)`) visszanavigál a fogadások képernyőre.

--- a/lib/screens/create_ticket_screen.dart
+++ b/lib/screens/create_ticket_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
-import '../providers/bet_slip_provider.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tippmixapp/l10n/app_localizations.dart';
+import 'package:tippmixapp/providers/auth_provider.dart';
+import 'package:tippmixapp/providers/bet_slip_provider.dart';
+import 'package:tippmixapp/routes/app_route.dart';
 import '../models/tip_model.dart';
 import '../services/bet_slip_service.dart';
-import 'package:tippmixapp/l10n/app_localizations.dart';
-import '../providers/auth_provider.dart';
 
 class CreateTicketScreen extends ConsumerStatefulWidget {
   const CreateTicketScreen({super.key});
@@ -60,16 +62,18 @@ class _CreateTicketScreenState extends ConsumerState<CreateTicketScreen> {
         return;
       }
       await BetSlipService.submitTicket(tips: tips, stake: stake.toInt());
+      if (!mounted) return;
       setState(() {
         _isLoading = false;
       });
-      if (mounted) {
-        ref.read(betSlipProvider.notifier).clearSlip();
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(loc.ticket_submit_success)));
-        Navigator.of(context).pop();
-      }
+      // Ürítsük a szelvényt sikeres beküldés után
+      ref.read(betSlipProvider.notifier).clearSlip();
+      // Diszkrét visszajelzés a meglévő kulccsal
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.ticket_submit_success)),
+      );
+      // routing_integrity: név alapú visszanavigálás a Fogadások képernyőre
+      context.goNamed(AppRoute.bets.name);
     } on FirebaseException catch (e) {
       setState(() {
         _isLoading = false;

--- a/lib/screens/events_screen.dart
+++ b/lib/screens/events_screen.dart
@@ -11,6 +11,7 @@ import '../models/tip_model.dart';
 import 'package:go_router/go_router.dart';
 import '../widgets/event_bet_card.dart';
 import '../services/api_football_service.dart';
+import 'package:tippmixapp/routes/app_route.dart';
 
 class EventsScreen extends ConsumerStatefulWidget {
   final String sportKey;
@@ -274,9 +275,7 @@ class _EventsScreenState extends ConsumerState<EventsScreen> {
               heroTag: 'createTicket',
               tooltip: loc.go_to_create_ticket,
               child: const Icon(Icons.check),
-              onPressed: () {
-                GoRouter.of(context).push('/create-ticket');
-              },
+              onPressed: () => context.pushNamed(AppRoute.createTicket.name),
             ),
           if (hasTips) const SizedBox(height: 12),
           FloatingActionButton(


### PR DESCRIPTION
## Summary
- clear bet slip and use GoRouter named navigation after ticket submit
- switch events FAB to named route
- document slip clear and named navigation in bet H2H docs

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test tools`
- `flutter test test/widget/events_screen_fab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68aad6f2fa2c832f996376d8075ddc69