### PR TITLE
fix: use wallet subdoc and update rules

### DIFF
--- a/cloud_functions/admin_coin_ops.ts
+++ b/cloud_functions/admin_coin_ops.ts
@@ -21,7 +21,7 @@ export const admin_coin_ops = onCall(async (request) => {
 
   const svc = new CoinService();
   if (operation === 'reset') {
-    const walletSnap = await db.doc(`users/${userId}/wallet`).get();
+    const walletSnap = await db.collection('users').doc(userId).collection('wallet').doc('main').get();
     const current = (walletSnap.get('coins') as number) || 0;
     if (current > 0) {
       await svc.debit(userId, current, `admin:reset:${Date.now()}`);

--- a/cloud_functions/firestore.rules
+++ b/cloud_functions/firestore.rules
@@ -136,7 +136,7 @@ service cloud.firestore {
     }
 
     /* --- NEW: user-centric wallet & ledger (SoT) --- */
-    match /users/{uid}/wallet {
+    match /users/{uid}/wallet/{docId} {
       allow read: if isOwner(uid);
       allow write: if false; // Only via CF (Admin SDK)
     }

--- a/cloud_functions/lib/admin_coin_ops.js
+++ b/cloud_functions/lib/admin_coin_ops.js
@@ -16,7 +16,7 @@ exports.admin_coin_ops = (0, https_1.onCall)(async (request) => {
     const { userId, amount, operation } = data;
     const svc = new CoinService_1.CoinService();
     if (operation === 'reset') {
-        const walletSnap = await firebase_1.db.doc(`users/${userId}/wallet`).get();
+        const walletSnap = await firebase_1.db.collection('users').doc(userId).collection('wallet').doc('main').get();
         const current = walletSnap.get('coins') || 0;
         if (current > 0) {
             await svc.debit(userId, current, `admin:reset:${Date.now()}`);

--- a/cloud_functions/lib/src/bonus_claim.js
+++ b/cloud_functions/lib/src/bonus_claim.js
@@ -29,7 +29,7 @@ exports.claim_daily_bonus = (0, https_1.onCall)(async (request) => {
     const todayKey = ymdUtc(now);
     const refId = `bonus:daily:${todayKey}`;
     const bonusStateRef = firebase_1.db.doc(`users/${uid}/bonus_state`);
-    const walletRef = firebase_1.db.doc(`users/${uid}/wallet`);
+    const walletRef = firebase_1.db.collection('users').doc(uid).collection('wallet').doc('main');
     await firebase_1.db.runTransaction(async (t) => {
         const [stateDoc, walletDoc] = await Promise.all([t.get(bonusStateRef), t.get(walletRef)]);
         const state = stateDoc.exists ? stateDoc.data() : {};

--- a/cloud_functions/lib/src/services/CoinService.js
+++ b/cloud_functions/lib/src/services/CoinService.js
@@ -13,7 +13,7 @@ class CoinService {
         t.set(ledgerRef, { type, amount, before, after, refId, source, checksum, createdAt: firestore_1.FieldValue.serverTimestamp() }, { merge: true });
     }
     async transact(uid, amount, refId, type, source, t, before) {
-        const walletRef = firebase_1.db.doc(`users/${uid}/wallet`);
+        const walletRef = firebase_1.db.collection('users').doc(uid).collection('wallet').doc('main');
         if (t) {
             const ledgerRef = firebase_1.db.collection('users').doc(uid).collection('ledger').doc(refId);
             // Idempotency: skip if ledger entry already exists

--- a/cloud_functions/src/bonus_claim.ts
+++ b/cloud_functions/src/bonus_claim.ts
@@ -32,7 +32,7 @@ export const claim_daily_bonus = onCall(async (request) => {
   const refId = `bonus:daily:${todayKey}`;
 
   const bonusStateRef = db.doc(`users/${uid}/bonus_state`);
-  const walletRef = db.doc(`users/${uid}/wallet`);
+  const walletRef = db.collection('users').doc(uid).collection('wallet').doc('main');
 
   await db.runTransaction(async (t) => {
     const [stateDoc, walletDoc] = await Promise.all([t.get(bonusStateRef), t.get(walletRef)]);

--- a/cloud_functions/src/services/CoinService.ts
+++ b/cloud_functions/src/services/CoinService.ts
@@ -33,7 +33,7 @@ export class CoinService {
     t?: Transaction,
     before?: number,
   ) {
-    const walletRef = db.doc(`users/${uid}/wallet`);
+    const walletRef = db.collection('users').doc(uid).collection('wallet').doc('main');
     if (t) {
       const ledgerRef = db.collection('users').doc(uid).collection('ledger').doc(refId);
       // Idempotency: skip if ledger entry already exists

--- a/firebase.rules
+++ b/firebase.rules
@@ -103,7 +103,7 @@ service cloud.firestore {
     }
 
     /* --- NEW: user-centric wallet & ledger (SoT) --- */
-    match /users/{uid}/wallet {
+    match /users/{uid}/wallet/{docId} {
       allow read: if isOwner(uid);
       allow write: if false; // Only via CF (Admin SDK)
     }

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -32,7 +32,7 @@ class StatsService {
       for (final userDoc in userSnap.docs) {
         final data = userDoc.data();
         final uid = userDoc.id;
-        final walletSnap = await _db.doc('users/$uid/wallet').get();
+        final walletSnap = await _db.doc('users/$uid/wallet/main').get();
         final coins = (walletSnap.data()?['coins'] as int?) ?? 0;
         final displayName = data['nickname'] as String? ?? '';
 
@@ -117,7 +117,7 @@ class StatsService {
     if (!userDoc.exists) return null;
     final userData = userDoc.data() ?? <String, dynamic>{};
 
-    final walletSnap = await _db.doc('users/$uid/wallet').get();
+    final walletSnap = await _db.doc('users/$uid/wallet/main').get();
     final coins = (walletSnap.data()?['coins'] as int?) ?? 0;
     final displayName = userData['nickname'] as String? ?? '';
 


### PR DESCRIPTION
## Summary
- align wallet references with `users/{uid}/wallet/main`
- secure wallet collection under new path in Firebase rules
- update stats service to read balance from `wallet/main`

## Testing
- `npm ci`
- `npm run build`
- `grep -R \`users/\${.*}/wallet\``
- `grep -R "doc('users/\$uid/wallet')" lib/`
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --coverage` *(fails: TestDeviceException - Shell subprocess terminated by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf61ee0e0832fa08a6a9fc321abb2