### PR TITLE
fix(wallet): enforce coin_trx callable and ledger fallback

### DIFF
--- a/docs/backend/coin_service_logic_en.md
+++ b/docs/backend/coin_service_logic_en.md
@@ -91,6 +91,7 @@ TippCoinLog {
 
 - `CoinService.debitCoin` and `creditCoin` only invoke `coin_trx`; all wallet updates happen server-side.
 - `CoinService.debitAndCreateTicket()` creates the ticket then triggers `coin_trx` debit.
+- If `coin_trx` is unavailable (e.g., local tests), a fallback writes to `users/{uid}/wallet/main` and `users/{uid}/ledger/{transactionId}` so paths stay consistent.
 - Wallet balance stored at `users/{uid}/wallet/main.coins` is treated as source of truth and updated by Cloud Functions.
 - `coin_logs` collection removed; per-user ledger is the sole transaction log.
 - Signup bonus and daily bonus claims are governed by `system_configs/bonus_rules`.

--- a/docs/backend/coin_service_logic_hu.md
+++ b/docs/backend/coin_service_logic_hu.md
@@ -92,6 +92,7 @@ TippCoinLog {
 
 - A `CoinService.debitCoin` és `creditCoin` csak a `coin_trx` függvényt hívja; minden wallet módosítás szerveroldalon zajlik.
 - A `CoinService.debitAndCreateTicket()` létrehozza a szelvényt, majd `coin_trx` segítségével vonja le a tétet.
+- Ha a `coin_trx` nem elérhető (pl. lokális tesztek), egy fallback tranzakció a `users/{uid}/wallet/main` és `users/{uid}/ledger/{transactionId}` útvonalakat használja, hogy az állapot konzisztens maradjon.
 - A wallet egyenleg forrása a `users/{uid}/wallet/main.coins`, melyet Cloud Function frissít.
 - A `coin_logs` gyűjtemény teljesen kivezetésre került, a ledger az egyetlen napló.
 - A regisztrációs és napi bónusz igénylését a `system_configs/bonus_rules` szabályozza.

--- a/lib/services/bet_slip_service.dart
+++ b/lib/services/bet_slip_service.dart
@@ -79,7 +79,7 @@ class BetSlipService {
     // 4️⃣ TippCoin levonás
     final cs =
         coinService ??
-        CoinService(firestore: firestore ?? FirebaseFirestore.instance);
+        CoinService.live(firestore: firestore ?? FirebaseFirestore.instance);
     await cs.debitAndCreateTicket(stake: stake, ticketData: ticket.toJson());
 
     if (kDebugMode) {

--- a/lib/services/coin_service.dart
+++ b/lib/services/coin_service.dart
@@ -188,9 +188,24 @@ class CoinService {
     required String reason,
     required String transactionId,
   }) async {
-    final uid = _fa.currentUser!.uid;
-    final walletRef = _fs.collection('wallets').doc(uid);
-    final ledgerRef = walletRef.collection('ledger').doc(transactionId);
+    final uid = _fa.currentUser?.uid;
+    if (uid == null) {
+      throw FirebaseAuthException(
+        code: 'unauthenticated',
+        message: 'User not logged in',
+      );
+    }
+    // User-centrikus SoT: users/{uid}/wallet (doc 'main') + users/{uid}/ledger/{transactionId}
+    final walletRef = _fs
+        .collection('users')
+        .doc(uid)
+        .collection('wallet')
+        .doc('main');
+    final ledgerRef = _fs
+        .collection('users')
+        .doc(uid)
+        .collection('ledger')
+        .doc(transactionId);
     await _wrapper.run((tx) async {
       final ledgerSnap = await tx.get(ledgerRef);
       if (ledgerSnap.exists) return;


### PR DESCRIPTION
## Summary
- ensure BetSlipService uses CoinService.live so debits call Cloud Function
- align CoinService ledger fallback with users/{uid}/wallet/main + ledger/{transactionId}
- note CF fallback path in coin service docs (EN & HU)

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test tools`
- `flutter test --coverage` *(fails: tapping create ticket navigates to screen when tips exist)*

------
https://chatgpt.com/codex/tasks/task_e_68aba56b7b68832fa2e2465810de4bb1