### PR TITLE
fix(match-finalizer): use env for ApiFootballResultProvider key

### DIFF
--- a/cloud_functions/src/match_finalizer.ts
+++ b/cloud_functions/src/match_finalizer.ts
@@ -9,8 +9,11 @@ import { db } from "./lib/firebase";
 import { PubSub } from "@google-cloud/pubsub";
 import { CoinService } from "./services/CoinService";
 import { getEvaluator, NormalizedResult } from "./evaluators";
+import { API_FOOTBALL_KEY } from "../global";
 
-const provider = new ApiFootballResultProvider();
+const provider = new ApiFootballResultProvider(
+  API_FOOTBALL_KEY.value() || process.env.API_FOOTBALL_KEY || ''
+);
 
 const pubsub = new PubSub();
 const RESULT_TOPIC = process.env.RESULT_TOPIC || "result-check";

--- a/cloud_functions/src/services/ApiFootballResultProvider.ts
+++ b/cloud_functions/src/services/ApiFootballResultProvider.ts
@@ -1,6 +1,6 @@
 // Lightweight API-Football provider
 // Node 18+ global fetch; no extra deps required
-import * as functions from 'firebase-functions';
+// v2 environment should avoid v1 firebase-functions config API
 
 export interface ScoreResult {
   id: string;
@@ -16,11 +16,7 @@ export class ApiFootballResultProvider {
   private readonly baseUrl = 'https://v3.football.api-sports.io';
   private readonly apiKey: string;
 
-  constructor(
-    apiKey =
-      (process.env.API_FOOTBALL_KEY || functions.config().apifootball?.key) ??
-      '',
-  ) {
+  constructor(apiKey: string = process.env.API_FOOTBALL_KEY ?? '') {
     this.apiKey = apiKey;
   }
 
@@ -88,8 +84,7 @@ export async function findFixtureIdByMeta(params: {
     .filter(Boolean);
   if (!home || !away) return null;
   const date = (params.startTime || '').slice(0, 10); // YYYY-MM-DD
-  const apiKey =
-    (process.env.API_FOOTBALL_KEY || functions.config().apifootball?.key) ?? '';
+  const apiKey = process.env.API_FOOTBALL_KEY ?? '';
   if (!apiKey || !date) return null;
 
   const base = 'https://v3.football.api-sports.io';

--- a/docs/backend/result_provider_en.md
+++ b/docs/backend/result_provider_en.md
@@ -6,6 +6,7 @@ Adapter around API-Football fixtures endpoint. In production it performs live HT
 - Batch requests in groups of 40 event IDs.
 - Falls back to local JSON when `MODE=dev` and mocking enabled.
 - Throws on missing `API_FOOTBALL_KEY` or non-200 responses.
+- Reads `API_FOOTBALL_KEY` from Secret Manager binding or environment variable; v1 `functions.config()` is no longer used.
 - Treats `FT/AET/PEN` statuses as completed and returns `winner` (home/away/draw).
 - Provides `findFixtureIdByMeta(eventName,startTime)` helper to resolve a `fixtureId` from team names and kickoff time when only metadata is available. It queries `GET /fixtures?date=YYYY-MM-DD&search=<team>` for both home and away names and returns the match with a case-insensitive name/date match.
 

--- a/docs/backend/result_provider_hu.md
+++ b/docs/backend/result_provider_hu.md
@@ -6,6 +6,8 @@ Az API-Football fixtures végpontját használó adapter. Prod módban élő HTT
 - Eseményazonosítókat 40-es csomagokra osztja.
 - `MODE=dev` esetén mock üzemmódra vált.
 - Hibát dob, ha hiányzik az `API_FOOTBALL_KEY` vagy a válasz nem 200-as.
+- Az `API_FOOTBALL_KEY` a Secret Manager bindingon vagy környezeti változón keresztül érkezik;
+  a v1 `functions.config()` már nem kerül felhasználásra.
 - `FT/AET/PEN` státuszokat lezártnak tekinti és visszaadja a `winner` mezőt (hazai/idegen/döntetlen).
 - `findFixtureIdByMeta(eventName,startTime)` segédfüggvény a `fixtureId` feloldására csapatnevek és kezdési idő alapján, ha csak metaadat áll rendelkezésre. A `GET /fixtures?date=YYYY-MM-DD&search=<team>` végpontot hívja meg mindkét csapatnévre, és kis/nagybetű-független név/idő egyezés alapján választja ki a megfelelő meccset.
 


### PR DESCRIPTION
## Summary
- remove firebase-functions v1 config usage from ApiFootballResultProvider
- inject Secret Manager API_FOOTBALL_KEY into match_finalizer
- document Secret Manager key usage for ApiFootballResultProvider

## Testing
- `./scripts/precommit.sh` *(fails: dart: command not found)*
- `npm ci --prefix cloud_functions`
- `npm test --prefix cloud_functions`
- `npm run build` in `cloud_functions/`
- `gcloud functions deploy ...` *(fails: command not found)*
- `gcloud pubsub topics publish ...` *(fails: command not found)*
- `gcloud functions logs read ...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0efb69e4832f8429e54d98fb4ede