### PR TITLE
refactor: finalize handler secrets and auth guard

### DIFF
--- a/cloud_functions/firestore.rules
+++ b/cloud_functions/firestore.rules
@@ -121,6 +121,18 @@ service cloud.firestore {
         allow read: if true;
         allow update: if false;
       }
+
+      // Friend requests (kliens által használt útvonal)
+      match /friendRequests/{requestId} {
+        // Létrehozás: a kérés feladója hozhat létre bejegyzést
+        allow create: if signedIn() && request.auth.uid == request.resource.data.fromUid;
+        // Olvasás: a cél user vagy a feladó olvashat
+        allow read: if isOwner(uid) || (signedIn() && request.auth.uid == request.resource.data.fromUid);
+        // Módosítás: a cél user jelölheti accepted=true-re
+        allow update: if signedIn() && isOwner(uid);
+        // Törlés tiltva
+        allow delete: if false;
+      }
     }
 
     /* ——— badgesProgress ——— */

--- a/cloud_functions/index.ts
+++ b/cloud_functions/index.ts
@@ -2,7 +2,6 @@ import './global';
 import { onMessagePublished } from 'firebase-functions/v2/pubsub';
 import type { CloudEvent } from 'firebase-functions/v2';
 import type { MessagePublishedData } from 'firebase-functions/v2/pubsub';
-import { API_FOOTBALL_KEY } from './global';
 import * as logger from 'firebase-functions/logger';
 import { match_finalizer as matchFinalizerHandler } from './src/match_finalizer';
 
@@ -12,12 +11,12 @@ export { onUserCreate, coin_trx } from './coin_trx.logic';
 export { onFriendRequestAccepted } from './friend_request';
 export { daily_bonus } from './src/daily_bonus';
 export { claim_daily_bonus } from './src/bonus_claim';
+export { admin_coin_ops } from './admin_coin_ops';
 
 // Global options a global.ts-ben kerül beállításra (régió + secretek)
 
 // Gen2 Pub/Sub trigger (topic: result-check, region via global options)
-export const match_finalizer = onMessagePublished(
-  { topic: 'result-check', secrets: [API_FOOTBALL_KEY], retry: true },
+export const match_finalizer = onMessagePublished('result-check',
   async (event: CloudEvent<MessagePublishedData>) => {
     // Védő log + guard, hogy üres event esetén is értelmezhető legyen a viselkedés
     const hasMsg = !!event?.data?.message;

--- a/cloud_functions/src/match_finalizer.ts
+++ b/cloud_functions/src/match_finalizer.ts
@@ -11,10 +11,6 @@ import { CoinService } from "./services/CoinService";
 import { getEvaluator, NormalizedResult } from "./evaluators";
 import { API_FOOTBALL_KEY } from "../global";
 
-const provider = new ApiFootballResultProvider(
-  API_FOOTBALL_KEY.value() || process.env.API_FOOTBALL_KEY || ''
-);
-
 const pubsub = new PubSub();
 const RESULT_TOPIC = process.env.RESULT_TOPIC || "result-check";
 const DLQ_TOPIC = process.env.DLQ_TOPIC || "result-check-dlq";
@@ -64,6 +60,10 @@ type JobType = "kickoff-tracker" | "result-poller" | "final-sweep";
 export const match_finalizer = async (
   message: PubSubMessage,
 ): Promise<"OK" | "RETRY" | "DLQ"> => {
+  // Provider példányosítás a handler scope‑ban – Secret olvasás futásidőben
+  const provider = new ApiFootballResultProvider(
+    API_FOOTBALL_KEY.value() || process.env.API_FOOTBALL_KEY || ''
+  );
   const attempt = Number((message?.attributes?.attempt as string) || "0");
   logger.info("match_finalizer.handle", {
     hasData: !!message?.data,

--- a/lib/services/social_service.dart
+++ b/lib/services/social_service.dart
@@ -11,7 +11,16 @@ class SocialService {
     : _firestore = firestore ?? FirebaseFirestore.instance,
       _auth = auth ?? FirebaseAuth.instance;
 
-  String get _uid => _auth.currentUser!.uid;
+  String get _uid {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw FirebaseAuthException(
+        code: 'not-authenticated',
+        message: 'User must be signed in',
+      );
+    }
+    return user.uid;
+  }
 
   Future<void> followUser(String targetUid) async {
     final ref = _firestore


### PR DESCRIPTION
## Summary
- scope provider inside match_finalizer so API_FOOTBALL_KEY is read at runtime
- simplify Pub/Sub trigger and export admin_coin_ops
- add friendRequests rules and guard SocialService user access

## Testing
- `npm -C cloud_functions ci --no-audit --no-fund --no-progress`
- `npm -C cloud_functions run lint --no-progress`
- `npm -C cloud_functions test --silent`
- `flutter analyze --no-fatal-infos lib test integration_test bin tool` *(fails: Flutter SDK version 0.0.0-unknown)*
- `flutter test --coverage` *(fails: Flutter SDK version 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b09f8588832faf6b54b60b65da74