### PR TITLE
MyTickets: add debug FAB to trigger match_finalizer

### DIFF
--- a/cloud_functions/index.ts
+++ b/cloud_functions/index.ts
@@ -14,6 +14,7 @@ export { reserve_nickname } from './src/username_reservation';
 export { onTicketWritten_indexFixture } from './fixtures_index';
 export { backfill_fixture_index } from './backfill_fixture_index';
 export { finalize_publish } from './src/finalize_publish';
+export { force_finalizer } from './src/force_finalizer';
 
 // Global options a global.ts-ben kerül beállításra (régió + secretek)
 

--- a/cloud_functions/lib/index.js
+++ b/cloud_functions/lib/index.js
@@ -33,7 +33,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.match_finalizer = exports.finalize_publish = exports.backfill_fixture_index = exports.onTicketWritten_indexFixture = exports.reserve_nickname = exports.admin_coin_ops = exports.claim_daily_bonus = exports.daily_bonus = exports.onFriendRequestAccepted = exports.coin_trx = exports.onUserCreate = void 0;
+exports.match_finalizer = exports.force_finalizer = exports.finalize_publish = exports.backfill_fixture_index = exports.onTicketWritten_indexFixture = exports.reserve_nickname = exports.admin_coin_ops = exports.claim_daily_bonus = exports.daily_bonus = exports.onFriendRequestAccepted = exports.coin_trx = exports.onUserCreate = void 0;
 require("./global");
 const pubsub_1 = require("firebase-functions/v2/pubsub");
 const logger = __importStar(require("firebase-functions/logger"));
@@ -59,6 +59,8 @@ var backfill_fixture_index_1 = require("./backfill_fixture_index");
 Object.defineProperty(exports, "backfill_fixture_index", { enumerable: true, get: function () { return backfill_fixture_index_1.backfill_fixture_index; } });
 var finalize_publish_1 = require("./src/finalize_publish");
 Object.defineProperty(exports, "finalize_publish", { enumerable: true, get: function () { return finalize_publish_1.finalize_publish; } });
+var force_finalizer_1 = require("./src/force_finalizer");
+Object.defineProperty(exports, "force_finalizer", { enumerable: true, get: function () { return force_finalizer_1.force_finalizer; } });
 // Global options a global.ts-ben kerül beállításra (régió + secretek)
 // Gen2 Pub/Sub trigger – topic: result-check
 exports.match_finalizer = (0, pubsub_1.onMessagePublished)('result-check', async (event) => {

--- a/cloud_functions/src/force_finalizer.ts
+++ b/cloud_functions/src/force_finalizer.ts
@@ -1,0 +1,33 @@
+import '../global';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { PubSub } from '@google-cloud/pubsub';
+
+const pubsub = new PubSub();
+const RESULT_TOPIC = process.env.RESULT_TOPIC || 'result-check';
+
+export const force_finalizer = onCall(async (request) => {
+  const ctx: any = request;
+  if (!ctx.auth) throw new HttpsError('unauthenticated', 'Auth required');
+
+  const isAdmin = Boolean((ctx.auth.token as any)?.admin);
+  const devOverride = Boolean(request.data?.devOverride);
+  const allowDev =
+    process.env.ALLOW_DEV_FORCE_FINALIZER === 'true' && devOverride;
+
+  if (!isAdmin && !allowDev) {
+    throw new HttpsError('permission-denied', 'Admin only');
+  }
+
+  const payload = {
+    type: 'final-sweep',
+    requestedBy: ctx.auth.uid,
+    ts: Date.now(),
+  };
+
+  await pubsub.topic(RESULT_TOPIC).publishMessage({
+    data: Buffer.from(JSON.stringify(payload), 'utf8'),
+    attributes: { attempt: '0' },
+  });
+
+  return { status: 'OK' };
+});

--- a/cloud_functions/test/force_finalizer.test.ts
+++ b/cloud_functions/test/force_finalizer.test.ts
@@ -1,0 +1,29 @@
+import { HttpsError } from 'firebase-functions/v2/https';
+
+const publishMessage = jest.fn().mockResolvedValue('1');
+const topic = jest.fn(() => ({ publishMessage }));
+jest.mock('@google-cloud/pubsub', () => ({
+  PubSub: jest.fn(() => ({ topic })),
+}));
+const { force_finalizer } = require('../src/force_finalizer');
+
+describe('force_finalizer', () => {
+  it('publishes final-sweep message for admin', async () => {
+    const result = await (force_finalizer as any).run({
+      auth: { uid: 'u1', token: { admin: true } },
+      data: {},
+    });
+    expect(result).toEqual({ status: 'OK' });
+    const call = publishMessage.mock.calls[0][0];
+    const payload = JSON.parse(call.data.toString());
+    expect(payload.type).toBe('final-sweep');
+    expect(payload.requestedBy).toBe('u1');
+    expect(typeof payload.ts).toBe('number');
+  });
+
+  it('rejects non-admin', async () => {
+    await expect(
+      (force_finalizer as any).run({ auth: { uid: 'u1', token: {} }, data: {} }),
+    ).rejects.toBeInstanceOf(HttpsError);
+  });
+});

--- a/lib/providers/admin_provider.dart
+++ b/lib/providers/admin_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides whether the current user has admin privileges.
+///
+/// In production this should reflect a custom claim from Firebase Auth.
+/// For now it defaults to `false` and can be overridden in tests.
+final isAdminProvider = Provider<bool>((ref) => false);

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -18,6 +18,13 @@ class AnalyticsService {
   final FirebaseAnalytics? _analytics;
   bool _exposedLogged = false;
 
+  Future<void> logEvent(String name,
+      {Map<String, Object>? parameters}) async {
+    try {
+      await _analytics?.logEvent(name: name, parameters: parameters);
+    } catch (_) {}
+  }
+
   Future<void> logLoginVariantExposed(String variant) async {
     if (_exposedLogged) return;
     _exposedLogged = true;

--- a/lib/services/finalizer_service.dart
+++ b/lib/services/finalizer_service.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_functions/cloud_functions.dart';
+
+/// Service to trigger the match finalizer Cloud Function manually.
+class FinalizerService {
+  /// Calls the `force_finalizer` HTTPS callable.
+  ///
+  /// [devOverride] can bypass admin restriction when the backend allows it.
+  static Future<String> forceFinalizer({
+    bool devOverride = false,
+    FirebaseFunctions? functions,
+  }) async {
+    try {
+      final instance =
+          functions ?? FirebaseFunctions.instanceFor(region: 'europe-central2');
+      final callable = instance.httpsCallable('force_finalizer');
+      final res = await callable.call(<String, dynamic>{
+        'devOverride': devOverride,
+      });
+      return (res.data is Map && res.data['status'] == 'OK') ? 'OK' : 'ERROR';
+    } catch (e) {
+      return 'ERROR: $e';
+    }
+  }
+}

--- a/test/services/finalizer_service_test.dart
+++ b/test/services/finalizer_service_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import 'package:tippmixapp/services/finalizer_service.dart';
+
+class FakeHttpsCallableResult<T> implements HttpsCallableResult<T> {
+  @override
+  final T data;
+  FakeHttpsCallableResult(this.data);
+}
+
+class FakeHttpsCallable extends Fake implements HttpsCallable {
+  Map<String, dynamic>? last;
+  final dynamic response;
+  final bool shouldThrow;
+  FakeHttpsCallable({this.response = const {'status': 'OK'}, this.shouldThrow = false});
+
+  @override
+  Future<HttpsCallableResult<T>> call<T>([dynamic parameters]) async {
+    last = Map<String, dynamic>.from(parameters as Map);
+    if (shouldThrow) {
+      throw FirebaseFunctionsException(
+        code: 'permission-denied',
+        message: 'denied',
+      );
+    }
+    return FakeHttpsCallableResult<T>(response as T);
+  }
+}
+
+class FakeFirebaseFunctions extends Fake implements FirebaseFunctions {
+  final FakeHttpsCallable callable;
+  FakeFirebaseFunctions(this.callable);
+
+  @override
+  HttpsCallable httpsCallable(String name, {HttpsCallableOptions? options}) {
+    return callable;
+  }
+}
+
+void main() {
+  test('returns OK on success', () async {
+    final callable = FakeHttpsCallable();
+    final functions = FakeFirebaseFunctions(callable);
+    final result = await FinalizerService.forceFinalizer(functions: functions);
+    expect(result, 'OK');
+    expect(callable.last, {'devOverride': false});
+  });
+
+  test('returns error string on failure', () async {
+    final callable = FakeHttpsCallable(shouldThrow: true);
+    final functions = FakeFirebaseFunctions(callable);
+    final result = await FinalizerService.forceFinalizer(functions: functions);
+    expect(result.startsWith('ERROR'), isTrue);
+  });
+}

--- a/test/widgets/my_tickets_force_fab_test.dart
+++ b/test/widgets/my_tickets_force_fab_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:tippmixapp/l10n/app_localizations.dart';
+import 'package:tippmixapp/models/auth_state.dart';
+import 'package:tippmixapp/models/user.dart' as app;
+import 'package:tippmixapp/providers/auth_provider.dart';
+import 'package:tippmixapp/services/auth_service.dart';
+import 'package:tippmixapp/screens/my_tickets_screen.dart'
+    show MyTicketsScreen, ticketsProvider;
+import 'package:tippmixapp/models/ticket_model.dart';
+
+class FakeAuthService implements AuthService {
+  final _controller = StreamController<app.User?>.broadcast();
+  app.User? _current;
+
+  @override
+  Stream<app.User?> authStateChanges() => _controller.stream;
+  @override
+  Future<app.User?> signInWithEmail(String email, String password) async => null;
+  @override
+  Future<app.User?> registerWithEmail(String email, String password) async => null;
+  @override
+  Future<void> signOut() async {
+    _current = null;
+    _controller.add(null);
+  }
+  @override
+  Future<void> sendEmailVerification() async {}
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+  @override
+  bool get isEmailVerified => true;
+  @override
+  app.User? get currentUser => _current;
+  @override
+  Future<bool> validateEmailUnique(String email) async => true;
+  @override
+  Future<bool> validateNicknameUnique(String nickname) async => true;
+  @override
+  Future<app.User?> signInWithGoogle() async => null;
+  @override
+  Future<app.User?> signInWithApple() async => null;
+  @override
+  Future<app.User?> signInWithFacebook() async => null;
+  @override
+  Future<bool> pollEmailVerification({
+    Duration timeout = const Duration(minutes: 3),
+    Duration interval = const Duration(seconds: 5),
+  }) async => true;
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
+}
+
+class FakeAuthNotifier extends AuthNotifier {
+  FakeAuthNotifier() : super(FakeAuthService()) {
+    state = const AuthState(user: null);
+  }
+}
+
+void main() {
+  testWidgets('shows FAB in debug mode', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ticketsProvider.overrideWith((ref) => Stream.value(const <Ticket>[])),
+          authServiceProvider.overrideWith((ref) => FakeAuthService()),
+          authProvider.overrideWith((ref) => FakeAuthNotifier()),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MyTicketsScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `force_finalizer` callable to publish final-sweep message
- wire up FinalizerService and admin-only debug FAB on MyTickets screen
- log analytics and include unit/widget tests

## Testing
- `npm run lint`
- `npm test`
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --coverage test/services/finalizer_service_test.dart test/widgets/my_tickets_force_fab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0bee018832fba1d58771fe49755