### PR TITLE
docs: add forum mvp discovery report

### DIFF
--- a/docs/reports/forum_mvp_discovery_REPORT.md
+++ b/docs/reports/forum_mvp_discovery_REPORT.md
@@ -1,0 +1,16 @@
+# Forum MVP discovery report
+
+## Paths
+- Router: `lib/router.dart`
+- Bottom navigation: `lib/widgets/my_bottom_navigation_bar.dart`
+- Firestore security rules: `firebase.rules`
+- Firestore indexes: `firestore.indexes.json`
+- Firebase Functions monorepo: `functions/`
+
+## API-Football key handling
+- Local development uses `.env` and `env.yaml` with `API_FOOTBALL_KEY`.
+- Cloud Functions access it via `process.env.API_FOOTBALL_KEY` or Secret Manager binding.
+
+## Versions
+- Flutter SDK: 3.8.1
+- App version: 1.4.0+1

--- a/docs/reports/forum_mvp_discovery_REPORT_hu.md
+++ b/docs/reports/forum_mvp_discovery_REPORT_hu.md
@@ -1,0 +1,16 @@
+# Fórum MVP feltérképezési jelentés
+
+## Elérési utak
+- Router: `lib/router.dart`
+- Alsó navigáció: `lib/widgets/my_bottom_navigation_bar.dart`
+- Firestore szabályok: `firebase.rules`
+- Firestore indexek: `firestore.indexes.json`
+- Firebase Functions monorepó: `functions/`
+
+## API-Football kulcs kezelése
+- Lokális fejlesztéskor az `API_FOOTBALL_KEY` az `.env` és `env.yaml` fájlokban található.
+- A Cloud Functions a `process.env.API_FOOTBALL_KEY` változón vagy Secret Manageren keresztül éri el.
+
+## Verziók
+- Flutter SDK: 3.8.1
+- Alkalmazás verzió: 1.4.0+1


### PR DESCRIPTION
## Summary
- document router, navigation, firestore config, and API-Football key handling for forum MVP

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test` *(interrupted by SIGINT; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc832694832fa3b25cc58c4dfd66