### PR TITLE
Profile: working avatar upload + rounded-square avatar

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,12 +6,14 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Tippmixapp</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>Allow selecting profile pictures</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>tippmixapp</string>
 	<key>CFBundlePackageType</key>

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /users/{userId}/avatar/{fileName} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/test/services/profile_service_avatar_test.dart
+++ b/test/services/profile_service_avatar_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -15,6 +16,7 @@ class MockUploadTask extends Mock implements UploadTask {}
 void main() {
   setUpAll(() {
     registerFallbackValue(File('fallback.png'));
+    registerFallbackValue(Uint8List(0));
   });
   group('ProfileService.uploadAvatar', () {
     late MockFirebaseStorage storage;
@@ -32,7 +34,7 @@ void main() {
       cache = FakeCache<UserModel>();
       when(() => storage.ref()).thenReturn(reference);
       when(() => reference.child(any())).thenReturn(reference);
-      when(() => reference.putFile(any(), any())).thenAnswer((_) => task);
+      when(() => reference.putData(any(), any())).thenAnswer((_) => task);
       when(
         () => reference.getDownloadURL(),
       ).thenAnswer((_) async => 'http://download');
@@ -68,6 +70,7 @@ void main() {
       expect(url, 'http://download');
       final doc = await firestore.collection('users').doc('u1').get();
       expect(doc.data()?['avatarUrl'], 'http://download');
+      verify(() => reference.child('users/u1/avatar/avatar_256.png')).called(1);
       // cleanup temp file
       try { await file.parent.delete(recursive: true); } catch (_) {}
     });

--- a/test/utils/image_resizer_test.dart
+++ b/test/utils/image_resizer_test.dart
@@ -1,0 +1,22 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tippmixapp/utils/image_resizer.dart';
+
+void main() {
+  test('cropSquareResize256 produces 256x256 under 150KB', () async {
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    final paint = ui.Paint()..color = const ui.Color(0xFF123456);
+    canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 400, 300), paint);
+    final image = await recorder.endRecording().toImage(400, 300);
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    final bytes = data!.buffer.asUint8List();
+    final out = await ImageResizer.cropSquareResize256(bytes);
+    expect(out.lengthInBytes < 150 * 1024, true);
+    final codec = await ui.instantiateImageCodec(out);
+    final frame = await codec.getNextFrame();
+    expect(frame.image.width, 256);
+    expect(frame.image.height, 256);
+  });
+}

--- a/test/widgets/profile_avatar_widget_test.dart
+++ b/test/widgets/profile_avatar_widget_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tippmixapp/screens/profile_screen.dart';
+
+void main() {
+  testWidgets('shows placeholder when url is null', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => buildAvatar(context, null, 'Alice'),
+        ),
+      ),
+    );
+    expect(find.text('A'), findsOneWidget);
+    expect(find.byType(ClipRRect), findsNothing);
+  });
+
+  testWidgets('shows rounded square when url provided', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => buildAvatar(context, 'http://example.com/a.png', 'Alice'),
+        ),
+      ),
+    );
+    expect(find.byType(ClipRRect), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- allow picking and uploading custom avatar images on profile screen
- process images to 256×256 and store at `users/<uid>/avatar/avatar_256.png`
- show rounded-square avatars with placeholder initials
- secure storage path and document iOS photo library usage

## Testing
- `flutter analyze lib test integration_test bin tool`
- `flutter test --coverage` *(failed: timeout in profile_avatar_upload_test)*

------
https://chatgpt.com/codex/tasks/task_e_68b90ac1f764832faedb38f7f06c215e