### PR TITLE
MyTickets: show force-finalizer FAB only for specific UID

### DIFF
--- a/docs/screens/my_tickets/screen_spec.md
+++ b/docs/screens/my_tickets/screen_spec.md
@@ -48,6 +48,7 @@
 * `lib/widgets/ticket_details_dialog.dart` – részletező: rövidített szelvényazonosító (első 4 + utolsó 4), létrehozás dátuma; függő státusznál legkorábbi tipp kezdési ideje; tippek státusz szerinti csoportosítása (Nyertes/Vesztes/Függőben) szekciókba, címkék: `loc.ticket_details_section_*` + darabszám. Szekció össze/kinyitás csak 2+ elemnél; 1 elemnél sima fejléc + sor. Sor tartalma: esemény cím, `outcome • market`, trailing: mini státusz‑chip + `xODDS`.
   * `lib/widgets/empty_ticket_placeholder.dart` – üres állapot, elsődleges CTA „Szelvény készítése” (GoRouter → `AppRoute.bets`).
   * Navigáció: `lib/widgets/app_drawer.dart`, `lib/widgets/my_bottom_navigation_bar.dart`.
+  * Fejlesztői `FloatingActionButton`: manuális szelvénykiértékelés indítása (csak uid = `2pEEqMzCsBfkrv4jWx3YP5yDb0F2`).
 * **Állapotok**:
 
   * [x] **Loading** — skeleton lista: `MyTicketsSkeleton`.

--- a/test/widgets/my_tickets_force_fab_test.dart
+++ b/test/widgets/my_tickets_force_fab_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:tippmixapp/l10n/app_localizations.dart';
 import 'package:tippmixapp/models/auth_state.dart';
@@ -12,6 +14,8 @@ import 'package:tippmixapp/services/auth_service.dart';
 import 'package:tippmixapp/screens/my_tickets_screen.dart'
     show MyTicketsScreen, ticketsProvider;
 import 'package:tippmixapp/models/ticket_model.dart';
+import 'package:tippmixapp/providers/onboarding_provider.dart'
+    show firebaseAuthProvider;
 
 class FakeAuthService implements AuthService {
   final _controller = StreamController<app.User?>.broadcast();
@@ -20,14 +24,17 @@ class FakeAuthService implements AuthService {
   @override
   Stream<app.User?> authStateChanges() => _controller.stream;
   @override
-  Future<app.User?> signInWithEmail(String email, String password) async => null;
+  Future<app.User?> signInWithEmail(String email, String password) async =>
+      null;
   @override
-  Future<app.User?> registerWithEmail(String email, String password) async => null;
+  Future<app.User?> registerWithEmail(String email, String password) async =>
+      null;
   @override
   Future<void> signOut() async {
     _current = null;
     _controller.add(null);
   }
+
   @override
   Future<void> sendEmailVerification() async {}
   @override
@@ -61,11 +68,21 @@ class FakeAuthNotifier extends AuthNotifier {
   }
 }
 
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class MockUser extends Mock implements User {}
+
 void main() {
-  testWidgets('shows FAB in debug mode', (tester) async {
+  testWidgets('FAB visible for allowed uid', (tester) async {
+    final mockUser = MockUser();
+    when(() => mockUser.uid).thenReturn('2pEEqMzCsBfkrv4jWx3YP5yDb0F2');
+    final mockAuth = MockFirebaseAuth();
+    when(() => mockAuth.currentUser).thenReturn(mockUser);
+
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          firebaseAuthProvider.overrideWithValue(mockAuth),
           ticketsProvider.overrideWith((ref) => Stream.value(const <Ticket>[])),
           authServiceProvider.overrideWith((ref) => FakeAuthService()),
           authProvider.overrideWith((ref) => FakeAuthNotifier()),
@@ -79,5 +96,30 @@ void main() {
     );
     await tester.pump();
     expect(find.byType(FloatingActionButton), findsOneWidget);
+  });
+
+  testWidgets('FAB hidden for other uids', (tester) async {
+    final mockUser = MockUser();
+    when(() => mockUser.uid).thenReturn('other');
+    final mockAuth = MockFirebaseAuth();
+    when(() => mockAuth.currentUser).thenReturn(mockUser);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          firebaseAuthProvider.overrideWithValue(mockAuth),
+          ticketsProvider.overrideWith((ref) => Stream.value(const <Ticket>[])),
+          authServiceProvider.overrideWith((ref) => FakeAuthService()),
+          authProvider.overrideWith((ref) => FakeAuthNotifier()),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MyTicketsScreen(),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(FloatingActionButton), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- show manual finalizer FAB only when FirebaseAuth uid matches `2pEEqMzCsBfkrv4jWx3YP5yDb0F2`
- maintain forcing state and trigger FinalizerService
- document developer FAB in MyTickets spec and add widget tests for visibility

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --coverage` *(fails: TimeoutException in profile_avatar_upload_test)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad0ebe5c832f9b62f0a9bd7ade51