### PR TITLE
chore: ignore analyzer infos in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
         run: flutter pub get
 
       - name: Analyze
-        run: flutter analyze --no-fatal-warnings lib test integration_test bin tool
+        run: flutter analyze --no-fatal-infos lib test integration_test bin tool
 
       - name: Tests (fast, no coverage)
         run: |


### PR DESCRIPTION
## Summary
- avoid treating info-level lints as errors by switching CI analysis to `--no-fatal-infos`

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --no-pub --concurrency 4 --reporter expanded --exclude-tags slow` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d8f3fd34832f9858f4bf4b84068d