### PR TITLE
feat(forum): add market snapshot adapter

### DIFF
--- a/docs/features/forum_module_plan_en.md
+++ b/docs/features/forum_module_plan_en.md
@@ -53,6 +53,7 @@ threads/{threadId}/posts/{postId}
 - Basic spam filter (length, profanity)
 - Post count per user stored in profile (e.g. for badges)
 - Optional: pinned threads or featured discussions
+- MarketSnapshotAdapter caches ApiFootball odds snapshots for the composer
 
 ---
 

--- a/docs/features/forum_module_plan_hu.md
+++ b/docs/features/forum_module_plan_hu.md
@@ -53,6 +53,7 @@ threads/{threadId}/posts/{postId}
 - Alap spam szűrés (hossz, trágár szavak)
 - Felhasználói statisztika: posztok száma (badge alap)
 - Opcionális: kiemelt szálak, rögzített témák
+- MarketSnapshotAdapter cache-eli az ApiFootball odds pillanatképet a komponálóhoz
 
 ---
 

--- a/lib/features/forum/services/market_snapshot_adapter.dart
+++ b/lib/features/forum/services/market_snapshot_adapter.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:tippmixapp/services/api_football_service.dart';
+
+/// Provides cached market/odd snapshots for the forum composer.
+class MarketSnapshotAdapter {
+  MarketSnapshotAdapter({ApiFootballService? api, Duration? ttl})
+    : _api = api ?? ApiFootballService(),
+      _ttl = ttl ?? const Duration(minutes: 15);
+
+  final ApiFootballService _api;
+  final Duration _ttl;
+  final _cache = <int, _CacheEntry>{};
+
+  /// Returns odds/market snapshot for [fixtureId].
+  /// Results are cached in-memory to avoid excessive API calls.
+  Future<Map<String, dynamic>> getSnapshot(int fixtureId, {int? season}) async {
+    final entry = _cache[fixtureId];
+    if (entry != null && DateTime.now().isBefore(entry.expiry)) {
+      return entry.data;
+    }
+    final data = await _api.getOddsForFixture(
+      fixtureId.toString(),
+      season: season,
+    );
+    _cache[fixtureId] = _CacheEntry(data, DateTime.now().add(_ttl));
+    return data;
+  }
+
+  /// Clears the in-memory cache.
+  void clearCache() => _cache.clear();
+}
+
+class _CacheEntry {
+  _CacheEntry(this.data, this.expiry);
+  final Map<String, dynamic> data;
+  final DateTime expiry;
+}

--- a/test/features/forum/services/market_snapshot_adapter_test.dart
+++ b/test/features/forum/services/market_snapshot_adapter_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tippmixapp/features/forum/services/market_snapshot_adapter.dart';
+import 'package:tippmixapp/services/api_football_service.dart';
+
+class _MockApiFootballService extends ApiFootballService {
+  int callCount = 0;
+
+  @override
+  Future<Map<String, dynamic>> getOddsForFixture(
+    String fixtureId, {
+    int? season,
+    bool includeBet1 = true,
+  }) async {
+    callCount++;
+    return {'fixture': fixtureId};
+  }
+}
+
+void main() {
+  test('caches market snapshot per fixture', () async {
+    final api = _MockApiFootballService();
+    final adapter = MarketSnapshotAdapter(api: api);
+
+    final first = await adapter.getSnapshot(42);
+    final second = await adapter.getSnapshot(42);
+
+    expect(first, second);
+    expect(api.callCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- cache ApiFootball odds snapshot for forum composer
- cover adapter with unit test
- note adapter in forum module docs

## Testing
- `flutter analyze lib test integration_test bin tool`
- `flutter test --concurrency=4`
- `markdownlint docs/features/forum_module_plan_en.md docs/features/forum_module_plan_hu.md`

------
https://chatgpt.com/codex/tasks/task_e_68ba0524e4bc832f82298b2b5d827dae