### PR TITLE
feat: expand forum models

### DIFF
--- a/lib/features/forum/data/firestore_forum_repository.dart
+++ b/lib/features/forum/data/firestore_forum_repository.dart
@@ -28,9 +28,8 @@ class FirestoreForumRepository implements ForumRepository {
       query = query.startAfter([Timestamp.fromDate(startAfter)]);
     }
     return query.snapshots().map(
-          (s) =>
-              s.docs.map((d) => Thread.fromJson(d.id, d.data())).toList(),
-        );
+      (s) => s.docs.map((d) => Thread.fromJson(d.id, d.data())).toList(),
+    );
   }
 
   @override
@@ -43,9 +42,8 @@ class FirestoreForumRepository implements ForumRepository {
       query = query.startAfter([Timestamp.fromDate(startAfter)]);
     }
     return query.snapshots().map(
-          (s) =>
-              s.docs.map((d) => Thread.fromJson(d.id, d.data())).toList(),
-        );
+      (s) => s.docs.map((d) => Thread.fromJson(d.id, d.data())).toList(),
+    );
   }
 
   @override
@@ -63,9 +61,8 @@ class FirestoreForumRepository implements ForumRepository {
       query = query.startAfter([Timestamp.fromDate(startAfter)]);
     }
     return query.snapshots().map(
-          (s) =>
-              s.docs.map((d) => Post.fromJson(d.id, d.data())).toList(),
-        );
+      (s) => s.docs.map((d) => Post.fromJson(d.id, d.data())).toList(),
+    );
   }
 
   @override
@@ -80,18 +77,16 @@ class FirestoreForumRepository implements ForumRepository {
   @override
   Future<void> voteOnPost({
     required String postId,
-    required int value,
     required String userId,
   }) async {
     final vote = Vote(
-      postId: postId,
+      id: '${postId}_$userId',
+      entityType: VoteEntityType.post,
+      entityId: postId,
       userId: userId,
-      value: value,
       createdAt: DateTime.now(),
     );
-    await _firestore.collection('votes').doc('${postId}_$userId').set(
-          vote.toJson(),
-        );
+    await _firestore.collection('votes').doc(vote.id).set(vote.toJson());
   }
 
   @override

--- a/lib/features/forum/data/forum_repository.dart
+++ b/lib/features/forum/data/forum_repository.dart
@@ -9,10 +9,7 @@ abstract class ForumRepository {
     DateTime? startAfter,
   });
 
-  Stream<List<Thread>> getRecentThreads({
-    int limit = 20,
-    DateTime? startAfter,
-  });
+  Stream<List<Thread>> getRecentThreads({int limit = 20, DateTime? startAfter});
 
   Stream<List<Post>> getPostsByThread(
     String threadId, {
@@ -22,11 +19,7 @@ abstract class ForumRepository {
 
   Future<void> addPost(Post post);
 
-  Future<void> voteOnPost({
-    required String postId,
-    required int value,
-    required String userId,
-  });
+  Future<void> voteOnPost({required String postId, required String userId});
 
   Future<void> reportPost(Report report);
 }

--- a/lib/features/forum/domain/post.dart
+++ b/lib/features/forum/domain/post.dart
@@ -5,7 +5,6 @@ enum PostType { tip, comment, system }
 
 extension PostTypeX on PostType {
   String toJson() => name;
-
   static PostType fromJson(String value) =>
       PostType.values.firstWhere((e) => e.name == value);
 }
@@ -17,7 +16,11 @@ class Post {
   final String userId;
   final PostType type;
   final String content;
+  final String? quotedPostId;
   final DateTime createdAt;
+  final DateTime? editedAt;
+  final int votesCount;
+  final bool isHidden;
 
   const Post({
     required this.id,
@@ -25,7 +28,11 @@ class Post {
     required this.userId,
     required this.type,
     required this.content,
+    this.quotedPostId,
     required this.createdAt,
+    this.editedAt,
+    this.votesCount = 0,
+    this.isHidden = false,
   });
 
   factory Post.fromJson(String id, Map<String, dynamic> json) {
@@ -35,7 +42,11 @@ class Post {
       userId: json['userId'] as String,
       type: PostTypeX.fromJson(json['type'] as String),
       content: json['content'] as String,
+      quotedPostId: json['quotedPostId'] as String?,
       createdAt: (json['createdAt'] as Timestamp).toDate(),
+      editedAt: (json['editedAt'] as Timestamp?)?.toDate(),
+      votesCount: json['votesCount'] as int? ?? 0,
+      isHidden: json['isHidden'] as bool? ?? false,
     );
   }
 
@@ -44,6 +55,10 @@ class Post {
     'userId': userId,
     'type': type.toJson(),
     'content': content,
+    'quotedPostId': quotedPostId,
     'createdAt': Timestamp.fromDate(createdAt),
+    'editedAt': editedAt != null ? Timestamp.fromDate(editedAt!) : null,
+    'votesCount': votesCount,
+    'isHidden': isHidden,
   };
 }

--- a/lib/features/forum/domain/report.dart
+++ b/lib/features/forum/domain/report.dart
@@ -1,32 +1,65 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+/// Entities that can be reported.
+enum ReportEntityType { post, thread }
+
+extension ReportEntityTypeX on ReportEntityType {
+  String toJson() => name;
+  static ReportEntityType fromJson(String value) =>
+      ReportEntityType.values.firstWhere((e) => e.name == value);
+}
+
+/// Status of a report.
+enum ReportStatus { open, resolved }
+
+extension ReportStatusX on ReportStatus {
+  String toJson() => name;
+  static ReportStatus fromJson(String value) =>
+      ReportStatus.values.firstWhere((e) => e.name == value);
+}
+
 /// Report document for moderation.
 class Report {
-  final String postId;
-  final String userId;
+  final String id;
+  final ReportEntityType entityType;
+  final String entityId;
   final String reason;
+  final String? message;
+  final String reporterId;
   final DateTime createdAt;
+  final ReportStatus status;
 
   const Report({
-    required this.postId,
-    required this.userId,
+    required this.id,
+    required this.entityType,
+    required this.entityId,
     required this.reason,
+    this.message,
+    required this.reporterId,
     required this.createdAt,
+    this.status = ReportStatus.open,
   });
 
-  factory Report.fromJson(Map<String, dynamic> json) {
+  factory Report.fromJson(String id, Map<String, dynamic> json) {
     return Report(
-      postId: json['postId'] as String,
-      userId: json['userId'] as String,
+      id: id,
+      entityType: ReportEntityTypeX.fromJson(json['entityType'] as String),
+      entityId: json['entityId'] as String,
       reason: json['reason'] as String,
+      message: json['message'] as String?,
+      reporterId: json['reporterId'] as String,
       createdAt: (json['createdAt'] as Timestamp).toDate(),
+      status: ReportStatusX.fromJson(json['status'] as String? ?? 'open'),
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'postId': postId,
-    'userId': userId,
+    'entityType': entityType.toJson(),
+    'entityId': entityId,
     'reason': reason,
+    'message': message,
+    'reporterId': reporterId,
     'createdAt': Timestamp.fromDate(createdAt),
+    'status': status.toJson(),
   };
 }

--- a/lib/features/forum/domain/thread.dart
+++ b/lib/features/forum/domain/thread.dart
@@ -1,35 +1,68 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+/// Type of the thread.
+enum ThreadType { general, match, system }
+
+extension ThreadTypeX on ThreadType {
+  String toJson() => name;
+  static ThreadType fromJson(String value) =>
+      ThreadType.values.firstWhere((e) => e.name == value);
+}
+
 /// Forum thread document.
 class Thread {
   final String id;
-  final String fixtureId;
-  final String type;
+  final String title;
+  final ThreadType type;
+  final String? fixtureId;
+  final String createdBy;
   final DateTime createdAt;
   final bool locked;
+  final bool pinned;
+  final DateTime lastActivityAt;
+  final int postsCount;
+  final int votesCount;
 
   const Thread({
     required this.id,
-    required this.fixtureId,
+    required this.title,
     required this.type,
+    this.fixtureId,
+    required this.createdBy,
     required this.createdAt,
     this.locked = false,
+    this.pinned = false,
+    required this.lastActivityAt,
+    this.postsCount = 0,
+    this.votesCount = 0,
   });
 
   factory Thread.fromJson(String id, Map<String, dynamic> json) {
     return Thread(
       id: id,
-      fixtureId: json['fixtureId'] as String,
-      type: json['type'] as String,
+      title: json['title'] as String,
+      type: ThreadTypeX.fromJson(json['type'] as String),
+      fixtureId: json['fixtureId'] as String?,
+      createdBy: json['createdBy'] as String,
       createdAt: (json['createdAt'] as Timestamp).toDate(),
       locked: json['locked'] as bool? ?? false,
+      pinned: json['pinned'] as bool? ?? false,
+      lastActivityAt: (json['lastActivityAt'] as Timestamp).toDate(),
+      postsCount: json['postsCount'] as int? ?? 0,
+      votesCount: json['votesCount'] as int? ?? 0,
     );
   }
 
   Map<String, dynamic> toJson() => {
+    'title': title,
+    'type': type.toJson(),
     'fixtureId': fixtureId,
-    'type': type,
+    'createdBy': createdBy,
     'createdAt': Timestamp.fromDate(createdAt),
     'locked': locked,
+    'pinned': pinned,
+    'lastActivityAt': Timestamp.fromDate(lastActivityAt),
+    'postsCount': postsCount,
+    'votesCount': votesCount,
   };
 }

--- a/lib/features/forum/domain/user_forum_prefs.dart
+++ b/lib/features/forum/domain/user_forum_prefs.dart
@@ -1,27 +1,32 @@
-/// Per-user fórum beállítások (mute, default filters)
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Per-user forum preferences.
 class UserForumPrefs {
-  final List<String> mutedLeagues; // ligaId-k
-  final List<String> mutedThreads; // threadId-k
-  final String defaultTab; // 'tips' | 'comments' | 'poll'
+  final String userId;
+  final List<String> followedThreadIds;
+  final Map<String, DateTime> lastReads;
 
   const UserForumPrefs({
-    this.mutedLeagues = const [],
-    this.mutedThreads = const [],
-    this.defaultTab = 'tips',
+    required this.userId,
+    this.followedThreadIds = const [],
+    this.lastReads = const {},
   });
 
-  Map<String, dynamic> toMap() => {
-    'mutedLeagues': mutedLeagues,
-    'mutedThreads': mutedThreads,
-    'defaultTab': defaultTab,
-  };
-
-  static UserForumPrefs fromMap(Map<String, dynamic>? m) {
-    final d = m ?? <String, dynamic>{};
+  factory UserForumPrefs.fromJson(String id, Map<String, dynamic> json) {
+    final lastReadsMap = (json['lastReads'] as Map<String, dynamic>? ?? {}).map(
+      (key, value) => MapEntry(key, (value as Timestamp).toDate()),
+    );
     return UserForumPrefs(
-      mutedLeagues: (d['mutedLeagues'] as List?)?.cast<String>() ?? const [],
-      mutedThreads: (d['mutedThreads'] as List?)?.cast<String>() ?? const [],
-      defaultTab: (d['defaultTab'] ?? 'tips').toString(),
+      userId: json['userId'] as String? ?? id,
+      followedThreadIds:
+          (json['followedThreadIds'] as List?)?.cast<String>() ?? const [],
+      lastReads: lastReadsMap,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+    'userId': userId,
+    'followedThreadIds': followedThreadIds,
+    'lastReads': lastReads.map((k, v) => MapEntry(k, Timestamp.fromDate(v))),
+  };
 }

--- a/lib/features/forum/domain/vote.dart
+++ b/lib/features/forum/domain/vote.dart
@@ -1,32 +1,44 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-/// Vote document linking a user to a post.
+/// Entity types that can receive votes.
+enum VoteEntityType { post }
+
+extension VoteEntityTypeX on VoteEntityType {
+  String toJson() => name;
+  static VoteEntityType fromJson(String value) =>
+      VoteEntityType.values.firstWhere((e) => e.name == value);
+}
+
+/// Vote document linking a user to an entity.
 class Vote {
-  final String postId;
+  final String id;
+  final VoteEntityType entityType;
+  final String entityId;
   final String userId;
-  final int value;
   final DateTime createdAt;
 
   const Vote({
-    required this.postId,
+    required this.id,
+    required this.entityType,
+    required this.entityId,
     required this.userId,
-    required this.value,
     required this.createdAt,
   });
 
-  factory Vote.fromJson(Map<String, dynamic> json) {
+  factory Vote.fromJson(String id, Map<String, dynamic> json) {
     return Vote(
-      postId: json['postId'] as String,
+      id: id,
+      entityType: VoteEntityTypeX.fromJson(json['entityType'] as String),
+      entityId: json['entityId'] as String,
       userId: json['userId'] as String,
-      value: json['value'] as int,
       createdAt: (json['createdAt'] as Timestamp).toDate(),
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'postId': postId,
+    'entityType': entityType.toJson(),
+    'entityId': entityId,
     'userId': userId,
-    'value': value,
     'createdAt': Timestamp.fromDate(createdAt),
   };
 }

--- a/test/features/forum/data/forum_repository_test.dart
+++ b/test/features/forum/data/forum_repository_test.dart
@@ -43,7 +43,9 @@ void main() {
       'type': 'tip',
       'threadId': 't1',
       'content': 'old',
-      'createdAt': Timestamp.fromDate(DateTime.now().subtract(const Duration(minutes: 1))),
+      'createdAt': Timestamp.fromDate(
+        DateTime.now().subtract(const Duration(minutes: 1)),
+      ),
     });
     await fs.collection('threads/t1/posts').doc('p2').set({
       'userId': 'u1',

--- a/test/features/forum/domain/model_serialization_test.dart
+++ b/test/features/forum/domain/model_serialization_test.dart
@@ -3,22 +3,30 @@ import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/vote.dart';
 import 'package:tipsterino/features/forum/domain/report.dart';
+import 'package:tipsterino/features/forum/domain/user_forum_prefs.dart';
 
 void main() {
   group('Thread', () {
     test('toJson/fromJson', () {
       final thread = Thread(
         id: 't1',
+        title: 'Hello',
+        type: ThreadType.general,
         fixtureId: 'f1',
-        type: 'pre',
+        createdBy: 'u1',
         createdAt: DateTime.utc(2024, 1, 1),
         locked: true,
+        pinned: false,
+        lastActivityAt: DateTime.utc(2024, 1, 2),
+        postsCount: 1,
+        votesCount: 2,
       );
       final json = thread.toJson();
       final copy = Thread.fromJson('t1', json);
       expect(copy.id, thread.id);
+      expect(copy.title, thread.title);
       expect(copy.locked, thread.locked);
-      expect(copy.createdAt.isAtSameMomentAs(thread.createdAt), true);
+      expect(copy.postsCount, thread.postsCount);
     });
 
     test('missing field throws', () {
@@ -34,12 +42,17 @@ void main() {
         userId: 'u1',
         type: PostType.tip,
         content: 'hello',
+        quotedPostId: 'q1',
         createdAt: DateTime.utc(2024, 1, 1),
+        editedAt: DateTime.utc(2024, 1, 2),
+        votesCount: 3,
+        isHidden: true,
       );
       final json = post.toJson();
       final copy = Post.fromJson('p1', json);
       expect(copy.type, post.type);
-      expect(copy.content, post.content);
+      expect(copy.quotedPostId, post.quotedPostId);
+      expect(copy.votesCount, post.votesCount);
     });
 
     test('missing field throws', () {
@@ -50,38 +63,65 @@ void main() {
   group('Vote', () {
     test('toJson/fromJson', () {
       final vote = Vote(
-        postId: 'p1',
+        id: 'v1',
+        entityType: VoteEntityType.post,
+        entityId: 'p1',
         userId: 'u1',
-        value: 1,
         createdAt: DateTime.utc(2024, 1, 1),
       );
       final json = vote.toJson();
-      final copy = Vote.fromJson(json);
-      expect(copy.value, vote.value);
-      expect(copy.postId, vote.postId);
+      final copy = Vote.fromJson('v1', json);
+      expect(copy.entityType, vote.entityType);
+      expect(copy.entityId, vote.entityId);
     });
 
     test('missing field throws', () {
-      expect(() => Vote.fromJson({}), throwsA(isA<TypeError>()));
+      expect(() => Vote.fromJson('v1', {}), throwsA(isA<TypeError>()));
     });
   });
 
   group('Report', () {
     test('toJson/fromJson', () {
       final report = Report(
-        postId: 'p1',
-        userId: 'u1',
+        id: 'r1',
+        entityType: ReportEntityType.post,
+        entityId: 'p1',
         reason: 'spam',
+        message: 'pls',
+        reporterId: 'u1',
         createdAt: DateTime.utc(2024, 1, 1),
+        status: ReportStatus.open,
       );
       final json = report.toJson();
-      final copy = Report.fromJson(json);
+      final copy = Report.fromJson('r1', json);
       expect(copy.reason, report.reason);
-      expect(copy.userId, report.userId);
+      expect(copy.reporterId, report.reporterId);
     });
 
     test('missing field throws', () {
-      expect(() => Report.fromJson({}), throwsA(isA<TypeError>()));
+      expect(() => Report.fromJson('r1', {}), throwsA(isA<TypeError>()));
+    });
+  });
+
+  group('UserForumPrefs', () {
+    test('toJson/fromJson', () {
+      final prefs = UserForumPrefs(
+        userId: 'u1',
+        followedThreadIds: ['t1'],
+        lastReads: {'t1': DateTime.utc(2024, 1, 1)},
+      );
+      final json = prefs.toJson();
+      final copy = UserForumPrefs.fromJson('u1', json);
+      expect(copy.followedThreadIds, prefs.followedThreadIds);
+      expect(
+        copy.lastReads['t1']!.isAtSameMomentAs(prefs.lastReads['t1']!),
+        isTrue,
+      );
+    });
+
+    test('missing map handled', () {
+      final copy = UserForumPrefs.fromJson('u1', {});
+      expect(copy.followedThreadIds, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
- model threads/posts/votes/reports/user prefs per forum canvas
- adjust repository signatures for new vote structure
- cover serialization with unit tests

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --concurrency=4` *(fails: No file or variants found for asset: .env.)*

------
https://chatgpt.com/codex/tasks/task_e_68bd847d7f40832f83e64c4e932db346