### PR TITLE
feat: harden forum rules and repository

### DIFF
--- a/docs/features/forum_module_plan_en.md
+++ b/docs/features/forum_module_plan_en.md
@@ -57,6 +57,17 @@ threads/{threadId}/posts/{postId}
 
 ---
 
+## 📇 Query → Index Mapping
+
+| Query | Firestore index |
+| --- | --- |
+| Threads by fixture | `(fixtureId ASC, type ASC, createdAt DESC)` |
+| Posts by thread | `(threadId ASC, createdAt DESC)` |
+| Votes by entity | `(entityType ASC, entityId ASC, createdAt DESC, userId ASC)` |
+| Reports by status | `(status ASC, createdAt DESC)` |
+
+---
+
 ## 🧪 Testing
 
 - Form validation tests

--- a/docs/features/forum_module_plan_hu.md
+++ b/docs/features/forum_module_plan_hu.md
@@ -57,6 +57,17 @@ threads/{threadId}/posts/{postId}
 
 ---
 
+## 📇 Lekérdezés → Index megfeleltetés
+
+| Lekérdezés | Firestore index |
+| --- | --- |
+| Szálak fixture alapján | `(fixtureId ASC, type ASC, createdAt DESC)` |
+| Posztok szál szerint | `(threadId ASC, createdAt DESC)` |
+| Szavazatok entitás szerint | `(entityType ASC, entityId ASC, createdAt DESC, userId ASC)` |
+| Jelentések státusz szerint | `(status ASC, createdAt DESC)` |
+
+---
+
 ## 🧪 Tesztelés
 
 - Űrlap validáció teszt

--- a/firebase.rules
+++ b/firebase.rules
@@ -158,17 +158,22 @@ service cloud.firestore {
     /* --- forum threads --- */
     match /threads/{threadId} {
       allow read: if true;
-      allow create: if signedIn();
+      allow create: if signedIn()
+        && request.resource.data.createdBy == request.auth.uid
+        && request.resource.data.keys().hasOnly(['title','type','fixtureId','createdBy','createdAt']);
       allow update, delete: if isModerator();
 
       match /posts/{postId} {
         allow read: if true;
         allow create: if signedIn()
           && request.resource.data.userId == request.auth.uid
-          && ['tip', 'comment', 'system'].has(request.resource.data.type);
+          && ['tip', 'comment', 'system'].has(request.resource.data.type)
+          && !get(/databases/$(database)/documents/threads/$(threadId)).data.locked
+          && request.resource.data.keys().hasOnly(['threadId','userId','type','content','quotedPostId','createdAt']);
         allow update: if isModerator() ||
-          (isOwner(request.resource.data.userId) &&
-           request.time.diff(resource.data.createdAt, 'minutes') <= 15);
+          (isOwner(request.resource.data.userId)
+            && request.time.diff(resource.data.createdAt, 'minutes') <= 15
+            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['content','editedAt']));
         allow delete: if isModerator();
       }
     }
@@ -178,16 +183,18 @@ service cloud.firestore {
       allow read: if true;
       allow create: if signedIn()
         && request.resource.data.userId == request.auth.uid
-        && voteId == request.resource.data.postId + '_' + request.auth.uid
-        && !exists(/databases/$(database)/documents/votes/$(voteId))
-        && (request.resource.data.value == 1 || request.resource.data.value == -1);
+        && request.resource.data.entityType == 'post'
+        && voteId == request.resource.data.entityId + '_' + request.auth.uid
+        && !exists(/databases/$(database)/documents/votes/$(voteId));
       allow delete: if isOwner(request.resource.data.userId) || isModerator();
       allow update: if false;
     }
 
     /* --- reports --- */
     match /reports/{reportId} {
-      allow create: if signedIn();
+      allow create: if signedIn()
+        && request.resource.data.reporterId == request.auth.uid
+        && !request.resource.data.keys().hasAny(['status']);
       allow read, update, delete: if isModerator();
     }
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -45,28 +45,85 @@
     },
     {
       "collectionGroup": "posts",
-      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "threadId", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
+        {
+          "fieldPath": "threadId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
     },
     {
       "collectionGroup": "threads",
-      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "fixtureId", "order": "ASCENDING" },
-        { "fieldPath": "type", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
+        {
+          "fieldPath": "fixtureId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
     },
     {
       "collectionGroup": "notifications",
-      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "threadId", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
-      ]
+        {
+          "fieldPath": "threadId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
+    },
+    {
+      "collectionGroup": "votes",
+      "fields": [
+        {
+          "fieldPath": "entityType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "entityId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
+    },
+    {
+      "collectionGroup": "reports",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ],
+      "queryScope": "COLLECTION"
     }
   ]
 }

--- a/lib/features/forum/data/firestore_forum_repository.dart
+++ b/lib/features/forum/data/firestore_forum_repository.dart
@@ -66,6 +66,21 @@ class FirestoreForumRepository implements ForumRepository {
   }
 
   @override
+  Future<void> addThread(Thread thread) async {
+    await _threadsCol.doc(thread.id).set(thread.toJson());
+  }
+
+  @override
+  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {
+    await _threadsCol.doc(threadId).update(data);
+  }
+
+  @override
+  Future<void> deleteThread(String threadId) async {
+    await _threadsCol.doc(threadId).delete();
+  }
+
+  @override
   Future<void> addPost(Post post) async {
     await _threadsCol
         .doc(post.threadId)

--- a/lib/features/forum/data/forum_repository.dart
+++ b/lib/features/forum/data/forum_repository.dart
@@ -17,6 +17,12 @@ abstract class ForumRepository {
     DateTime? startAfter,
   });
 
+  Future<void> addThread(Thread thread);
+
+  Future<void> updateThread(String threadId, Map<String, dynamic> data);
+
+  Future<void> deleteThread(String threadId);
+
   Future<void> addPost(Post post);
 
   Future<void> voteOnPost({required String postId, required String userId});


### PR DESCRIPTION
## Summary
- expand forum repository with thread CRUD helpers
- tighten Firestore security rules for posts, votes and reports
- document and index forum queries

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --concurrency=4` *(fails: AppBarThemeData incompatibility in flex_color_scheme)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8722f51c832f8737cf7ae9a0515b