### PR TITLE
feat: add forum controllers

### DIFF
--- a/lib/features/forum/providers/composer_controller.dart
+++ b/lib/features/forum/providers/composer_controller.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/forum_repository.dart';
+import '../domain/post.dart';
+import '../domain/thread.dart';
+
+/// Handles creating new threads and posts.
+class ComposerController extends StateNotifier<AsyncValue<void>> {
+  ComposerController(this._repository) : super(const AsyncData(null));
+
+  final ForumRepository _repository;
+
+  /// Creates a thread with its first post.
+  Future<void> createThread(Thread thread, Post firstPost) async {
+    state = const AsyncLoading();
+    try {
+      await _repository.addThread(thread);
+      await _repository.addPost(firstPost);
+      state = const AsyncData(null);
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
+}

--- a/lib/features/forum/providers/forum_filter_state.dart
+++ b/lib/features/forum/providers/forum_filter_state.dart
@@ -1,0 +1,34 @@
+/// Available thread filters.
+enum ForumFilter { all, matches, general, pinned }
+
+/// Sort options for thread listing.
+enum ForumSort { latest, newest }
+
+/// Holds current filter and sort settings for the forum.
+class ForumFilterState {
+  const ForumFilterState({
+    this.filter = ForumFilter.all,
+    this.sort = ForumSort.latest,
+  });
+
+  final ForumFilter filter;
+  final ForumSort sort;
+
+  ForumFilterState copyWith({ForumFilter? filter, ForumSort? sort}) {
+    return ForumFilterState(
+      filter: filter ?? this.filter,
+      sort: sort ?? this.sort,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ForumFilterState &&
+        other.filter == filter &&
+        other.sort == sort;
+  }
+
+  @override
+  int get hashCode => Object.hash(filter, sort);
+}

--- a/lib/features/forum/providers/thread_detail_controller.dart
+++ b/lib/features/forum/providers/thread_detail_controller.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/forum_repository.dart';
+import '../domain/post.dart';
+import '../domain/report.dart';
+
+/// Manages a single thread's post list and actions.
+class ThreadDetailController extends StateNotifier<AsyncValue<List<Post>>> {
+  ThreadDetailController(this._repository, this.threadId)
+      : super(const AsyncLoading()) {
+    _subscribe();
+  }
+
+  final ForumRepository _repository;
+  final String threadId;
+  StreamSubscription<List<Post>>? _sub;
+  DateTime? _last;
+
+  void _subscribe({DateTime? startAfter}) {
+    _sub?.cancel();
+    final stream =
+        _repository.getPostsByThread(threadId, startAfter: startAfter);
+    _sub = stream.listen(
+      (posts) {
+        _last = posts.isNotEmpty ? posts.last.createdAt : _last;
+        state = AsyncData([
+          if (startAfter != null && state.hasValue) ...state.value!,
+          ...posts,
+        ]);
+      },
+      onError: (e, st) => state = AsyncError(e, st),
+    );
+  }
+
+  /// Loads the next page of posts.
+  void loadMore() => _subscribe(startAfter: _last);
+
+  Future<void> addPost(Post post) => _repository.addPost(post);
+
+  Future<void> voteOnPost(String postId, String userId) =>
+      _repository.voteOnPost(postId: postId, userId: userId);
+
+  Future<void> reportPost(Report report) => _repository.reportPost(report);
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/forum/providers/thread_list_controller.dart
+++ b/lib/features/forum/providers/thread_list_controller.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/forum_repository.dart';
+import '../domain/thread.dart';
+import 'forum_filter_state.dart';
+
+/// Controls the list of forum threads based on [ForumFilterState].
+class ThreadListController extends StateNotifier<AsyncValue<List<Thread>>> {
+  ThreadListController(this._repository, this._filter)
+      : super(const AsyncLoading()) {
+    _subscribe();
+  }
+
+  final ForumRepository _repository;
+  final ForumFilterState _filter;
+  StreamSubscription<List<Thread>>? _sub;
+  DateTime? _last;
+
+  void _subscribe({DateTime? startAfter}) {
+    _sub?.cancel();
+    final stream = _repository.getRecentThreads(startAfter: startAfter);
+    _sub = stream.listen(
+      (threads) {
+        _last = threads.isNotEmpty ? threads.last.createdAt : _last;
+        state = AsyncData([
+          if (startAfter != null && state.hasValue) ...state.value!,
+          ...threads,
+        ]);
+      },
+      onError: (e, st) => state = AsyncError(e, st),
+    );
+  }
+
+  /// Loads the next page of threads.
+  void loadMore() => _subscribe(startAfter: _last);
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/test/features/forum/providers/composer_controller_test.dart
+++ b/test/features/forum/providers/composer_controller_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/composer_controller.dart';
+
+class _MockRepo extends Mock implements ForumRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Thread(
+      id: 't',
+      title: 'a',
+      type: ThreadType.general,
+      createdBy: 'u',
+      createdAt: DateTime.now(),
+      lastActivityAt: DateTime.now(),
+    ));
+    registerFallbackValue(Post(
+      id: 'p',
+      threadId: 't',
+      userId: 'u',
+      type: PostType.tip,
+      content: 'c',
+      createdAt: DateTime.now(),
+    ));
+  });
+
+  test('createThread writes thread and post', () async {
+    final repo = _MockRepo();
+    when(() => repo.addThread(any())).thenAnswer((_) async {});
+    when(() => repo.addPost(any())).thenAnswer((_) async {});
+    final controller = ComposerController(repo);
+    final thread = Thread(
+      id: 't1',
+      title: 'x',
+      type: ThreadType.general,
+      createdBy: 'u1',
+      createdAt: DateTime.now(),
+      lastActivityAt: DateTime.now(),
+    );
+    final post = Post(
+      id: 'p1',
+      threadId: 't1',
+      userId: 'u1',
+      type: PostType.tip,
+      content: 'hi',
+      createdAt: DateTime.now(),
+    );
+    final future = controller.createThread(thread, post);
+    expect(controller.state, const AsyncLoading());
+    await future;
+    expect(controller.state, const AsyncData<void>(null));
+    verify(() => repo.addThread(thread)).called(1);
+    verify(() => repo.addPost(post)).called(1);
+  });
+}

--- a/test/features/forum/providers/thread_detail_controller_test.dart
+++ b/test/features/forum/providers/thread_detail_controller_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/domain/report.dart';
+import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
+
+class _MockRepo extends Mock implements ForumRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Post(
+      id: 'p',
+      threadId: 't',
+      userId: 'u',
+      type: PostType.tip,
+      content: 'c',
+      createdAt: DateTime.now(),
+    ));
+    registerFallbackValue(Report(
+      id: 'r',
+      entityType: ReportEntityType.post,
+      entityId: 'p',
+      reason: 'spam',
+      reporterId: 'u',
+      createdAt: DateTime.now(),
+    ));
+  });
+
+  test('emits posts from repository', () async {
+    final repo = _MockRepo();
+    final posts = [
+      Post(
+        id: 'p1',
+        threadId: 't1',
+        userId: 'u1',
+        type: PostType.tip,
+        content: 'hi',
+        createdAt: DateTime.now(),
+      ),
+    ];
+    when(() => repo.getPostsByThread('t1', startAfter: any(named: 'startAfter')))
+        .thenAnswer((_) => Stream.value(posts));
+    final controller = ThreadDetailController(repo, 't1');
+    await Future.delayed(Duration.zero);
+    expect(controller.state.value, posts);
+    controller.dispose();
+  });
+
+  test('actions delegate to repository', () async {
+    final repo = _MockRepo();
+    when(() => repo.getPostsByThread('t1', startAfter: any(named: 'startAfter')))
+        .thenAnswer((_) => const Stream.empty());
+    when(() => repo.addPost(any())).thenAnswer((_) async {});
+    when(() => repo.voteOnPost(postId: any(named: 'postId'), userId: any(named: 'userId')))
+        .thenAnswer((_) async {});
+    when(() => repo.reportPost(any())).thenAnswer((_) async {});
+    final controller = ThreadDetailController(repo, 't1');
+    final post = Post(
+      id: 'p2',
+      threadId: 't1',
+      userId: 'u1',
+      type: PostType.tip,
+      content: 'hi',
+      createdAt: DateTime.now(),
+    );
+    final report = Report(
+      id: 'r1',
+      entityType: ReportEntityType.post,
+      entityId: 'p2',
+      reason: 'spam',
+      reporterId: 'u1',
+      createdAt: DateTime.now(),
+    );
+    await controller.addPost(post);
+    await controller.voteOnPost('p2', 'u1');
+    await controller.reportPost(report);
+    verify(() => repo.addPost(post)).called(1);
+    verify(() => repo.voteOnPost(postId: 'p2', userId: 'u1')).called(1);
+    verify(() => repo.reportPost(report)).called(1);
+    controller.dispose();
+  });
+}

--- a/test/features/forum/providers/thread_list_controller_test.dart
+++ b/test/features/forum/providers/thread_list_controller_test.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
+import 'package:tipsterino/features/forum/providers/thread_list_controller.dart';
+
+class _MockRepo extends Mock implements ForumRepository {}
+
+void main() {
+  test('emits threads from repository', () async {
+    final repo = _MockRepo();
+    final threads = [
+      Thread(
+        id: 't1',
+        title: 'hi',
+        type: ThreadType.general,
+        createdBy: 'u1',
+        createdAt: DateTime.now(),
+        lastActivityAt: DateTime.now(),
+      ),
+    ];
+    when(() => repo.getRecentThreads(startAfter: any(named: 'startAfter')))
+        .thenAnswer((_) => Stream.value(threads));
+
+    final controller = ThreadListController(repo, const ForumFilterState());
+    await Future.delayed(Duration.zero);
+    expect(controller.state.value, threads);
+    controller.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add Riverpod controllers for forum threads and posts
- expose forum filter state
- cover controllers with unit tests

## Testing
- `flutter analyze lib test integration_test bin tool` *(fails: /workspace/flutter_sdk/packages/flutter_tools missing)*
- `flutter test --concurrency=4` *(fails: /workspace/flutter_sdk/packages/flutter_tools missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd93ec3084832f9aeb3788a9a7449e