### PR TITLE
feat: navigate forum fab to new thread

### DIFF
--- a/canvases/screens/forum_module_mvp.md
+++ b/canvases/screens/forum_module_mvp.md
@@ -28,7 +28,7 @@ The following tasks are organized by priority. Each task has **completion criter
   Add validation (title, first post, type). Navigate to thread view after success.
   **Done when**: Invalid inputs show errors, success redirects to thread with first post visible.
 
-* [ ] **Forum FAB navigation**
+* [x] **Forum FAB navigation**
   Connect FAB on Forum list to New Thread screen.
   **Done when**: Clicking FAB opens new thread form.
 

--- a/docs/features/forum_module_plan_en.md
+++ b/docs/features/forum_module_plan_en.md
@@ -74,6 +74,7 @@ threads/{threadId}/posts/{postId}
 - NewThreadScreen for creating threads
 - Firestore security rules for threads, posts, votes and reports
 - Central routing with ThreadViewScreen and composer
+- Forum list FAB navigates to NewThreadScreen
 - Bottom navigation entry for forum
 - threadDetailControllerProviderFamily export
 - Auth UID wired for thread/post creation; JSON payloads limited to rule-allowed fields

--- a/docs/features/forum_module_plan_hu.md
+++ b/docs/features/forum_module_plan_hu.md
@@ -74,6 +74,7 @@ threads/{threadId}/posts/{postId}
 - NewThreadScreen új szál létrehozásához
 - Firestore security rules a szálakra, posztokra, szavazatokra és jelentésekre
 - Központi router ThreadViewScreen-nel és komponálóval
+- Fórumlista FAB megnyitja a NewThreadScreen-t
 - Fórum fül az alsó navigációban
 - threadDetailControllerProviderFamily export
 - Auth UID bekötve a szál/poszt létrehozásnál; JSON csak rules által engedett mezőket küld

--- a/lib/screens/forum/forum_screen.dart
+++ b/lib/screens/forum/forum_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/forum/providers/forum_filter_state.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/forum_provider.dart';
+import '../../routes/app_route.dart';
+import 'package:go_router/go_router.dart';
 
 /// Displays a list of forum threads with basic filtering and sorting.
 class ForumScreen extends ConsumerWidget {
@@ -96,7 +98,7 @@ class ForumScreen extends ConsumerWidget {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: () => context.pushNamed(AppRoute.newThread.name),
         child: const Icon(Icons.add),
       ),
     );

--- a/test/widget/forum_fab_navigation_test.dart
+++ b/test/widget/forum_fab_navigation_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/domain/report.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/composer_controller.dart';
+import 'package:tipsterino/l10n/app_localizations.dart';
+import 'package:tipsterino/models/auth_state.dart';
+import 'package:tipsterino/models/user.dart';
+import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/forum_provider.dart';
+import 'package:tipsterino/routes/app_route.dart';
+import 'package:tipsterino/screens/forum/forum_screen.dart';
+import 'package:tipsterino/screens/forum/new_thread_screen.dart';
+
+import '../mocks/mock_auth_service.dart';
+
+class _FakeRepo implements ForumRepository {
+  @override
+  Future<void> addPost(Post post) async {}
+
+  @override
+  Future<void> addThread(Thread thread) async {}
+
+  @override
+  Future<void> deleteThread(String threadId) async {}
+
+  @override
+  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
+
+  @override
+  Future<void> deletePost({required String threadId, required String postId}) async {}
+
+  @override
+  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Stream<List<Thread>> getRecentThreads({int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Future<void> reportPost(Report report) async {}
+
+  @override
+  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
+
+  @override
+  Future<void> voteOnPost({required String postId, required String userId}) async {}
+}
+
+class _FakeComposer extends ComposerController {
+  _FakeComposer() : super(_FakeRepo());
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier() : super(MockAuthService()) {
+    state = AuthState(user: User(id: 'u1', email: '', displayName: '')); 
+  }
+}
+
+void main() {
+  testWidgets('FAB opens new thread form', (tester) async {
+    final router = GoRouter(
+      initialLocation: '/forum',
+      routes: [
+        GoRoute(
+          path: '/forum',
+          name: AppRoute.forum.name,
+          builder: (context, state) => const ForumScreen(),
+          routes: [
+            GoRoute(
+              path: 'new',
+              name: AppRoute.newThread.name,
+              builder: (context, state) => const NewThreadScreen(),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          composerControllerProvider.overrideWith((ref) => _FakeComposer()),
+          authProvider.overrideWith((ref) => _FakeAuthNotifier()),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NewThreadScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- route forum list FAB to the new thread form using GoRouter
- cover FAB navigation with a widget test
- mark forum FAB checklist item done and document navigation in forum module plan

## Testing
- `flutter analyze lib test integration_test bin tool` *(fails: tipsterino requires SDK version ^3.8.1)*
- `flutter test --concurrency=4` *(fails: AppBarThemeData assignment error in flex_color_scheme)*

------
https://chatgpt.com/codex/tasks/task_e_68be0e456ccc832f94885157b0a91e22