### PR TITLE
feat(forum): handle post actions

### DIFF
--- a/canvases/screens/forum_module_mvp.md
+++ b/canvases/screens/forum_module_mvp.md
@@ -20,7 +20,7 @@ The following tasks are organized by priority. Each task has **completion criter
   Replace all hardcoded userIds with the Firebase Auth UID. Ensure Firestore writes only send allowed fields per rules.
   **Done when**: All writes succeed on emulator without `permission-denied`.
 
-* [ ] **Wire UI actions in Thread View**
+* [x] **Wire UI actions in Thread View**
   Implement Reply, Add Comment, Edit (owner), Delete (owner), Upvote, Report buttons. Add optimistic updates + error handling.
   **Done when**: All icons trigger correct behavior with feedback.
 

--- a/docs/features/forum_module_plan_en.md
+++ b/docs/features/forum_module_plan_en.md
@@ -78,6 +78,7 @@ threads/{threadId}/posts/{postId}
 - Bottom navigation entry for forum
 - threadDetailControllerProviderFamily export
 - Auth UID wired for thread/post creation; JSON payloads limited to rule-allowed fields
+- ThreadViewScreen post actions (reply, edit, delete, upvote, report) with error handling
 
 ## 🧪 Testing
 

--- a/docs/features/forum_module_plan_hu.md
+++ b/docs/features/forum_module_plan_hu.md
@@ -78,6 +78,7 @@ threads/{threadId}/posts/{postId}
 - Fórum fül az alsó navigációban
 - threadDetailControllerProviderFamily export
 - Auth UID bekötve a szál/poszt létrehozásnál; JSON csak rules által engedett mezőket küld
+- ThreadViewScreen poszt műveletek (válasz, szerkesztés, törlés, szavazat, jelentés) hibakezeléssel
 
 ## 🧪 Tesztelés
 

--- a/lib/screens/forum/post_item.dart
+++ b/lib/screens/forum/post_item.dart
@@ -6,104 +6,169 @@ import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 
-class PostItem extends ConsumerWidget {
+class PostItem extends ConsumerStatefulWidget {
   const PostItem({super.key, required this.post, this.onReply});
 
   final Post post;
   final VoidCallback? onReply;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PostItem> createState() => _PostItemState();
+}
+
+class _PostItemState extends ConsumerState<PostItem> {
+  bool _loading = false;
+  bool _liked = false;
+
+  Future<void> _showError(BuildContext context) async {
+    final loc = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(loc.unknown_error_try_again)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final user = ref.watch(authProvider).user;
-    final isOwner = user?.id == post.userId;
+    final isOwner = user?.id == widget.post.userId;
     return ListTile(
-      title: Text(post.content),
-      subtitle: Text(post.userId),
+      title: Text(widget.post.content),
+      subtitle: Text(widget.post.userId),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
             icon: const Icon(Icons.reply),
             tooltip: loc.dialog_comment_title,
-            onPressed: onReply,
+            onPressed: _loading ? null : widget.onReply,
           ),
           if (isOwner)
             IconButton(
               icon: const Icon(Icons.edit),
               tooltip: loc.edit_title,
-              onPressed: () async {
-                final controller = TextEditingController(text: post.content);
-                final result = await showDialog<String>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: Text(loc.edit_title),
-                    content: TextField(controller: controller),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context),
-                        child: Text(loc.dialog_cancel),
-                      ),
-                      TextButton(
-                        onPressed: () =>
-                            Navigator.pop(context, controller.text.trim()),
-                        child: Text(loc.dialog_send),
-                      ),
-                    ],
-                  ),
-                );
-                if (result != null && result.isNotEmpty) {
-                  await ref
-                      .read(threadDetailControllerProviderFamily(post.threadId)
-                          .notifier)
-                      .updatePost(post.id, result);
-                }
-              },
+              onPressed: _loading
+                  ? null
+                  : () async {
+                      final controller =
+                          TextEditingController(text: widget.post.content);
+                      final result = await showDialog<String>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: Text(loc.edit_title),
+                          content: TextField(controller: controller),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context),
+                              child: Text(loc.dialog_cancel),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(
+                                  context, controller.text.trim()),
+                              child: Text(loc.dialog_send),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (result != null && result.isNotEmpty) {
+                        setState(() => _loading = true);
+                        try {
+                          await ref
+                              .read(threadDetailControllerProviderFamily(
+                                      widget.post.threadId)
+                                  .notifier)
+                              .updatePost(widget.post.id, result);
+                        } catch (_) {
+                          await _showError(context);
+                        } finally {
+                          if (mounted) setState(() => _loading = false);
+                        }
+                      }
+                    },
             ),
           if (isOwner)
             IconButton(
               icon: const Icon(Icons.delete),
               tooltip: loc.dialog_cancel,
-              onPressed: () async {
-                await ref
-                    .read(threadDetailControllerProviderFamily(post.threadId)
-                        .notifier)
-                    .deletePost(post.id);
-              },
+              onPressed: _loading
+                  ? null
+                  : () async {
+                      setState(() => _loading = true);
+                      try {
+                        await ref
+                            .read(threadDetailControllerProviderFamily(
+                                    widget.post.threadId)
+                                .notifier)
+                            .deletePost(widget.post.id);
+                      } catch (_) {
+                        await _showError(context);
+                      } finally {
+                        if (mounted) setState(() => _loading = false);
+                      }
+                    },
             ),
           IconButton(
-            icon: const Icon(Icons.thumb_up),
+            icon: Icon(Icons.thumb_up,
+                color: _liked
+                    ? Theme.of(context).colorScheme.primary
+                    : null),
             tooltip: loc.feed_like,
-            onPressed: () {
-              final uid = user?.id; // auth.uid for vote idempotency
-              if (uid != null) {
-                ref
-                    .read(threadDetailControllerProviderFamily(post.threadId)
-                        .notifier)
-                    .voteOnPost(post.id, uid);
-              }
-            },
+            onPressed: _loading
+                ? null
+                : () async {
+                    final uid = user?.id; // auth.uid for vote idempotency
+                    if (uid != null) {
+                      setState(() {
+                        _liked = !_liked;
+                        _loading = true;
+                      });
+                      try {
+                        await ref
+                            .read(threadDetailControllerProviderFamily(
+                                    widget.post.threadId)
+                                .notifier)
+                            .voteOnPost(widget.post.id, uid);
+                      } catch (_) {
+                        setState(() => _liked = !_liked); // revert
+                        await _showError(context);
+                      } finally {
+                        if (mounted) setState(() => _loading = false);
+                      }
+                    }
+                  },
           ),
           IconButton(
             icon: const Icon(Icons.flag),
             tooltip: loc.feed_report,
-            onPressed: () {
-              final uid = user?.id; // auth.uid per rules
-              if (uid != null) {
-                final report = Report(
-                  id: '',
-                  entityType: ReportEntityType.post,
-                  entityId: post.id,
-                  reporterId: uid, // reporterId must equal auth.uid
-                  reason: 'inappropriate',
-                  createdAt: DateTime.now(),
-                );
-                ref
-                    .read(threadDetailControllerProviderFamily(post.threadId)
-                        .notifier)
-                    .reportPost(report);
-              }
-            },
+            onPressed: _loading
+                ? null
+                : () async {
+                    final uid = user?.id; // auth.uid per rules
+                    if (uid != null) {
+                      final report = Report(
+                        id: '',
+                        entityType: ReportEntityType.post,
+                        entityId: widget.post.id,
+                        reporterId: uid, // reporterId must equal auth.uid
+                        reason: 'inappropriate',
+                        createdAt: DateTime.now(),
+                      );
+                      setState(() => _loading = true);
+                      try {
+                        await ref
+                            .read(threadDetailControllerProviderFamily(
+                                    widget.post.threadId)
+                                .notifier)
+                            .reportPost(report);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(loc.feed_report_success)),
+                        );
+                      } catch (_) {
+                        await _showError(context);
+                      } finally {
+                        if (mounted) setState(() => _loading = false);
+                      }
+                    }
+                  },
           ),
         ],
       ),

--- a/test/widget/post_item_actions_test.dart
+++ b/test/widget/post_item_actions_test.dart
@@ -1,23 +1,176 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tipsterino/screens/forum/post_item.dart';
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/domain/report.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
+import 'package:tipsterino/models/auth_state.dart';
+import 'package:tipsterino/models/user.dart';
+import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/forum_provider.dart';
+import 'package:tipsterino/screens/forum/post_item.dart';
+import 'package:tipsterino/l10n/app_localizations.dart';
+
+class _DummyRepo implements ForumRepository {
+  @override
+  Future<void> addPost(Post post) async {}
+
+  @override
+  Future<void> addThread(Thread thread) async {}
+
+  @override
+  Future<void> deletePost({required String threadId, required String postId}) async {}
+
+  @override
+  Future<void> deleteThread(String threadId) async {}
+
+  @override
+  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Stream<List<Thread>> getRecentThreads({int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
+
+  @override
+  Future<void> reportPost(Report report) async {}
+
+  @override
+  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
+
+  @override
+  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
+
+  @override
+  Future<void> voteOnPost({required String postId, required String userId}) async {}
+}
+
+class _FakeAuth extends StateNotifier<AuthState> {
+  _FakeAuth() : super(AuthState(user: User(id: 'u1', email: '', displayName: '')));
+}
+
+class _TestController extends ThreadDetailController {
+  _TestController() : super(_DummyRepo(), 't1');
+
+  bool addCalled = false;
+  bool updateCalled = false;
+  bool deleteCalled = false;
+  bool voteCalled = false;
+  bool reportCalled = false;
+
+  @override
+  Future<void> addPost(Post post) async {
+    addCalled = true;
+  }
+
+  @override
+  Future<void> updatePost(String postId, String content) async {
+    updateCalled = true;
+  }
+
+  @override
+  Future<void> deletePost(String postId) async {
+    deleteCalled = true;
+  }
+
+  @override
+  Future<void> voteOnPost(String postId, String userId) async {
+    voteCalled = true;
+  }
+
+  @override
+  Future<void> reportPost(Report report) async {
+    reportCalled = true;
+  }
+}
+
+class _FailVoteController extends _TestController {
+  @override
+  Future<void> voteOnPost(String postId, String userId) async {
+    throw Exception('fail');
+  }
+}
 
 void main() {
-  testWidgets('post item shows action buttons', (tester) async {
-    final post = Post(
-      id: 'p1',
-      threadId: 't1',
-      userId: 'u1',
-      type: PostType.comment,
-      content: 'Hi',
-      createdAt: DateTime.now(),
+  final post = Post(
+    id: 'p1',
+    threadId: 't1',
+    userId: 'u1',
+    type: PostType.comment,
+    content: 'hello',
+    createdAt: DateTime(2024),
+  );
+
+  testWidgets('buttons call controller methods', (tester) async {
+    final controller = _TestController();
+    var replied = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => _FakeAuth()),
+          threadDetailControllerProviderFamily('t1').overrideWith((ref) => controller),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PostItem(
+            post: post,
+            onReply: () => replied = true,
+          ),
+        ),
+      ),
     );
-    await tester.pumpWidget(MaterialApp(home: PostItem(post: post)));
-    expect(find.byIcon(Icons.reply), findsOneWidget);
-    expect(find.byIcon(Icons.edit), findsOneWidget);
-    expect(find.byIcon(Icons.delete), findsOneWidget);
-    expect(find.byIcon(Icons.thumb_up), findsOneWidget);
-    expect(find.byIcon(Icons.flag), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.reply));
+    expect(replied, isTrue);
+
+    await tester.tap(find.byIcon(Icons.edit));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'edited');
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(controller.updateCalled, isTrue);
+
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+    expect(controller.deleteCalled, isTrue);
+
+    await tester.tap(find.byIcon(Icons.thumb_up));
+    await tester.pumpAndSettle();
+    expect(controller.voteCalled, isTrue);
+
+    await tester.tap(find.byIcon(Icons.flag));
+    await tester.pumpAndSettle();
+    expect(controller.reportCalled, isTrue);
+  });
+
+  testWidgets('vote failure shows error and reverts state', (tester) async {
+    final controller = _FailVoteController();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => _FakeAuth()),
+          threadDetailControllerProviderFamily('t1').overrideWith((ref) => controller),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PostItem(post: post),
+        ),
+      ),
+    );
+
+    final initialColor = tester.widget<Icon>(find.byIcon(Icons.thumb_up)).color;
+    await tester.tap(find.byIcon(Icons.thumb_up));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    final afterColor = tester.widget<Icon>(find.byIcon(Icons.thumb_up)).color;
+    expect(afterColor, initialColor);
+    expect(find.text('Unknown error, please try again'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add error handling and optimistic updates for forum post actions
- cover post item actions with widget tests
- document thread view actions in forum module plan

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool` *(fails: The current Dart SDK version is 3.4.1. Because tipsterino requires SDK version ^3.8.1)*
- `flutter test --concurrency=4` *(fails: The current Dart SDK version is 3.4.1. Because tipsterino requires SDK version ^3.8.1)*
- `./scripts/lint_docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be52afe4f4832f808fd9968a205127