### PR TITLE
fix: resolve analyzer errors in forum tests

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -910,6 +910,90 @@ abstract class AppLocalizations {
   /// **'Thread is locked'**
   String get forum_thread_locked;
 
+  /// No description provided for @forum_thread_locked_banner.
+  ///
+  /// In en, this message translates to:
+  /// **'Thread is locked'**
+  String get forum_thread_locked_banner;
+
+  /// No description provided for @moderator_menu_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Moderator'**
+  String get moderator_menu_title;
+
+  /// No description provided for @pin_thread.
+  ///
+  /// In en, this message translates to:
+  /// **'Pin thread'**
+  String get pin_thread;
+
+  /// No description provided for @unpin_thread.
+  ///
+  /// In en, this message translates to:
+  /// **'Unpin thread'**
+  String get unpin_thread;
+
+  /// No description provided for @lock_thread.
+  ///
+  /// In en, this message translates to:
+  /// **'Lock thread'**
+  String get lock_thread;
+
+  /// No description provided for @unlock_thread.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlock thread'**
+  String get unlock_thread;
+
+  /// No description provided for @moderator_action_success.
+  ///
+  /// In en, this message translates to:
+  /// **'Action completed'**
+  String get moderator_action_success;
+
+  /// No description provided for @moderator_action_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Action failed'**
+  String get moderator_action_failed;
+
+  /// No description provided for @vote_count.
+  ///
+  /// In en, this message translates to:
+  /// **'Votes: {count}'**
+  String vote_count(Object count);
+
+  /// No description provided for @thread_type.
+  ///
+  /// In en, this message translates to:
+  /// **'Thread type'**
+  String get thread_type;
+
+  /// No description provided for @thread_type_general.
+  ///
+  /// In en, this message translates to:
+  /// **'General'**
+  String get thread_type_general;
+
+  /// No description provided for @thread_type_match.
+  ///
+  /// In en, this message translates to:
+  /// **'Match'**
+  String get thread_type_match;
+
+  /// No description provided for @fixture_id_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixture ID'**
+  String get fixture_id_label;
+
+  /// No description provided for @error_edit_time_expired.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit window expired'**
+  String get error_edit_time_expired;
+
   /// No description provided for @forum_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -429,6 +429,50 @@ class AppLocalizationsDe extends AppLocalizations {
   String get forum_thread_locked => 'Thread ist gesperrt';
 
   @override
+  String get forum_thread_locked_banner => 'Thread ist gesperrt';
+
+  @override
+  String get moderator_menu_title => 'Moderator';
+
+  @override
+  String get pin_thread => 'Thread anheften';
+
+  @override
+  String get unpin_thread => 'Anheftung lösen';
+
+  @override
+  String get lock_thread => 'Thread sperren';
+
+  @override
+  String get unlock_thread => 'Sperre aufheben';
+
+  @override
+  String get moderator_action_success => 'Aktion erfolgreich';
+
+  @override
+  String get moderator_action_failed => 'Aktion fehlgeschlagen';
+
+  @override
+  String vote_count(Object count) {
+    return 'Stimmen: $count';
+  }
+
+  @override
+  String get thread_type => 'Thread-Typ';
+
+  @override
+  String get thread_type_general => 'Allgemein';
+
+  @override
+  String get thread_type_match => 'Match';
+
+  @override
+  String get fixture_id_label => 'Spiel-ID';
+
+  @override
+  String get error_edit_time_expired => 'Bearbeitungszeit abgelaufen';
+
+  @override
   String get forum_title => 'Forum';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -420,6 +420,50 @@ class AppLocalizationsEn extends AppLocalizations {
   String get forum_thread_locked => 'Thread is locked';
 
   @override
+  String get forum_thread_locked_banner => 'Thread is locked';
+
+  @override
+  String get moderator_menu_title => 'Moderator';
+
+  @override
+  String get pin_thread => 'Pin thread';
+
+  @override
+  String get unpin_thread => 'Unpin thread';
+
+  @override
+  String get lock_thread => 'Lock thread';
+
+  @override
+  String get unlock_thread => 'Unlock thread';
+
+  @override
+  String get moderator_action_success => 'Action completed';
+
+  @override
+  String get moderator_action_failed => 'Action failed';
+
+  @override
+  String vote_count(Object count) {
+    return 'Votes: $count';
+  }
+
+  @override
+  String get thread_type => 'Thread type';
+
+  @override
+  String get thread_type_general => 'General';
+
+  @override
+  String get thread_type_match => 'Match';
+
+  @override
+  String get fixture_id_label => 'Fixture ID';
+
+  @override
+  String get error_edit_time_expired => 'Edit window expired';
+
+  @override
   String get forum_title => 'Forum';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -428,6 +428,50 @@ class AppLocalizationsHu extends AppLocalizations {
   String get forum_thread_locked => 'A szál zárolva van';
 
   @override
+  String get forum_thread_locked_banner => 'A szál zárolva van';
+
+  @override
+  String get moderator_menu_title => 'Moderátor';
+
+  @override
+  String get pin_thread => 'Szál rögzítése';
+
+  @override
+  String get unpin_thread => 'Rögzítés feloldása';
+
+  @override
+  String get lock_thread => 'Szál zárolása';
+
+  @override
+  String get unlock_thread => 'Zárolás feloldása';
+
+  @override
+  String get moderator_action_success => 'Művelet sikeres';
+
+  @override
+  String get moderator_action_failed => 'Művelet sikertelen';
+
+  @override
+  String vote_count(Object count) {
+    return 'Szavazatok: $count';
+  }
+
+  @override
+  String get thread_type => 'Téma típusa';
+
+  @override
+  String get thread_type_general => 'Általános';
+
+  @override
+  String get thread_type_match => 'Mérkőzés';
+
+  @override
+  String get fixture_id_label => 'Mérkőzés azonosító';
+
+  @override
+  String get error_edit_time_expired => 'A szerkesztési idő lejárt';
+
+  @override
   String get forum_title => 'Fórum';
 
   @override

--- a/lib/providers/forum_provider.dart
+++ b/lib/providers/forum_provider.dart
@@ -9,7 +9,6 @@ import '../features/forum/providers/thread_list_controller.dart';
 import '../features/forum/providers/composer_controller.dart';
 import '../features/forum/providers/thread_detail_controller.dart';
 import '../features/forum/domain/post.dart';
-import '../features/forum/domain/thread.dart';
 import 'admin_provider.dart';
 
 /// Provides the [ForumRepository] implementation.

--- a/lib/screens/forum/thread_view_screen.dart
+++ b/lib/screens/forum/thread_view_screen.dart
@@ -4,11 +4,10 @@ import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
-
-enum _ModAction { pin, lock }
-
 import 'composer_bar.dart';
 import 'post_item.dart';
+
+enum _ModAction { pin, lock }
 
 class ThreadViewScreen extends ConsumerStatefulWidget {
   const ThreadViewScreen({super.key, required this.threadId});

--- a/test/mocks/fake_forum_repository.dart
+++ b/test/mocks/fake_forum_repository.dart
@@ -1,0 +1,71 @@
+import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/domain/report.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
+
+class FakeForumRepository implements ForumRepository {
+  @override
+  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
+          {int limit = 20, DateTime? startAfter}) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Thread>> queryThreads(
+          {required ForumFilter filter,
+          required ForumSort sort,
+          int limit = 20,
+          DateTime? startAfter}) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Post>> getPostsByThread(String threadId,
+          {int limit = 20, DateTime? startAfter}) =>
+      const Stream.empty();
+
+  @override
+  Stream<Thread> watchThread(String threadId) => const Stream.empty();
+
+  @override
+  Future<void> addThread(Thread thread) async {}
+
+  @override
+  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
+
+  @override
+  Future<void> setThreadPinned(String threadId, bool pinned) async {}
+
+  @override
+  Future<void> setThreadLocked(String threadId, bool locked) async {}
+
+  @override
+  Future<void> deleteThread(String threadId) async {}
+
+  @override
+  Future<void> addPost(Post post) async {}
+
+  @override
+  Future<void> updatePost(
+          {required String threadId,
+          required String postId,
+          required String content}) async {}
+
+  @override
+  Future<void> deletePost(
+          {required String threadId, required String postId}) async {}
+
+  @override
+  Future<void> voteOnPost({required String postId, required String userId}) async {}
+
+  @override
+  Future<void> unvoteOnPost({required String postId, required String userId}) async {}
+
+  @override
+  Future<bool> hasVoted(
+          {required String postId, required String userId}) async =>
+      false;
+
+  @override
+  Future<void> reportPost(Report report) async {}
+}
+

--- a/test/widget/forum_fab_navigation_test.dart
+++ b/test/widget/forum_fab_navigation_test.dart
@@ -3,10 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
-import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/composer_controller.dart';
 import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/features/forum/providers/thread_list_controller.dart';
@@ -20,49 +16,10 @@ import 'package:tipsterino/screens/forum/forum_screen.dart';
 import 'package:tipsterino/screens/forum/new_thread_screen.dart';
 
 import '../mocks/mock_auth_service.dart';
-
-class _FakeRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeComposer extends ComposerController {
-  _FakeComposer() : super(_FakeRepo());
+  _FakeComposer() : super(FakeForumRepository());
 }
 
 class _FakeAuthNotifier extends AuthNotifier {
@@ -97,7 +54,7 @@ void main() {
           composerControllerProvider.overrideWith((ref) => _FakeComposer()),
           authProvider.overrideWith((ref) => _FakeAuthNotifier()),
           threadListControllerProvider.overrideWith(
-            (ref) => ThreadListController(_FakeRepo(), const ForumFilterState()),
+            (ref) => ThreadListController(FakeForumRepository(), const ForumFilterState()),
           ),
         ],
         child: MaterialApp.router(

--- a/test/widget/post_item_actions_test.dart
+++ b/test/widget/post_item_actions_test.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/models/auth_state.dart';
 import 'package:tipsterino/models/user.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
@@ -14,64 +11,7 @@ import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/post_item.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import '../mocks/mock_auth_service.dart';
-
-class _DummyRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  }) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(
-    String threadId, {
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(
-    String fixtureId, {
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({
-    required String postId,
-    required String userId,
-  }) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeAuth extends AuthNotifier {
   _FakeAuth() : super(MockAuthService()) {
@@ -82,7 +22,7 @@ class _FakeAuth extends AuthNotifier {
 }
 
 class _TestController extends ThreadDetailController {
-  _TestController() : super(_DummyRepo(), 't1');
+  _TestController() : super(FakeForumRepository(), 't1');
 
   bool addCalled = false;
   bool updateCalled = false;

--- a/test/widget/thread_view_locked_test.dart
+++ b/test/widget/thread_view_locked_test.dart
@@ -7,13 +7,11 @@ import 'package:tipsterino/screens/forum/composer_bar.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadDetailController {
-  _FakeController() : super(_DummyRepo(), 't1');
+  _FakeController() : super(FakeForumRepository(), 't1');
 
   bool addCalled = false;
 
@@ -23,69 +21,28 @@ class _FakeController extends ThreadDetailController {
   }
 }
 
-class _DummyRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  }) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-}
-
 void main() {
   testWidgets('shows banner and prevents posting when locked', (tester) async {
     final controller = _FakeController();
+    final lockedThread = Thread(
+      id: 't1',
+      title: 't1',
+      type: ThreadType.general,
+      createdBy: 'u1',
+      createdAt: DateTime.now(),
+      lastActivityAt: DateTime.now(),
+      locked: true,
+    );
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           threadDetailControllerProviderFamily('t1').overrideWith((ref) => controller),
+          threadProviderFamily.overrideWith((ref, id) => Stream.value(lockedThread)),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: const ThreadViewScreen(threadId: 't1', locked: true),
+          home: const ThreadViewScreen(threadId: 't1'),
         ),
       ),
     );
@@ -98,10 +55,19 @@ void main() {
   });
 
   testWidgets('composer enabled when unlocked', (tester) async {
+    final thread = Thread(
+      id: 't1',
+      title: 't1',
+      type: ThreadType.general,
+      createdBy: 'u1',
+      createdAt: DateTime.now(),
+      lastActivityAt: DateTime.now(),
+    );
     await tester.pumpWidget(ProviderScope(
       overrides: [
         threadDetailControllerProviderFamily('t1')
             .overrideWith((ref) => _FakeController()),
+        threadProviderFamily.overrideWith((ref, id) => Stream.value(thread)),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/widget/thread_view_screen_state_test.dart
+++ b/test/widget/thread_view_screen_state_test.dart
@@ -5,66 +5,12 @@ import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
-
-class _DummyRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  }) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadDetailController {
   _FakeController(AsyncValue<List<Post>> state)
-      : super(_DummyRepo(), 't1') {
+      : super(FakeForumRepository(), 't1') {
     this.state = state;
   }
 }

--- a/test/widgets/forum_lock_behavior_test.dart
+++ b/test/widgets/forum_lock_behavior_test.dart
@@ -4,67 +4,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadDetailController {
-  _FakeController() : super(_DummyRepo(), 't1') {
+  _FakeController() : super(FakeForumRepository(), 't1') {
     state = const AsyncData(<Post>[]);
   }
-}
-
-class _DummyRepo implements ForumRepository {
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Stream<List<Thread>> queryThreads(
-          {required ForumFilter filter,
-          required ForumSort sort,
-          int limit = 20,
-          DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost(
-          {required String threadId,
-          required String postId,
-          required String content}) async {}
-  @override
-  Future<void> deletePost(
-          {required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(report) async {}
-  @override
-  Future<void> unvoteOnPost(
-          {required String postId, required String userId}) async {}
-  @override
-  Future<bool> hasVoted(
-          {required String postId, required String userId}) async =>
-      false;
-  @override
-  Stream<Thread> watchThread(String threadId) => const Stream.empty();
-  @override
-  Future<void> setThreadPinned(String threadId, bool pinned) async {}
-  @override
-  Future<void> setThreadLocked(String threadId, bool locked) async {}
 }
 
 void main() {

--- a/test/widgets/forum_locked_test.dart
+++ b/test/widgets/forum_locked_test.dart
@@ -4,11 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadDetailController {
   _FakeController() : super(_DummyRepo(), 't1') {
@@ -16,33 +16,7 @@ class _FakeController extends ThreadDetailController {
   }
 }
 
-class _DummyRepo implements ForumRepository {
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> queryThreads({required ForumFilter filter, required ForumSort sort, int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(report) async {}
-  @override
-  Future<void> unvoteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<bool> hasVoted({required String postId, required String userId}) async => false;
+class _DummyRepo extends FakeForumRepository {
   @override
   Stream<Thread> watchThread(String threadId) => Stream.value(Thread(
         id: 't1',

--- a/test/widgets/forum_match_thread_test.dart
+++ b/test/widgets/forum_match_thread_test.dart
@@ -10,39 +10,12 @@ import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
 import 'package:tipsterino/models/auth_state.dart';
 import 'package:tipsterino/models/user.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
 import '../mocks/mock_auth_service.dart';
-
-class _FakeRepo implements ForumRepository {
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Stream<List<Thread>> queryThreads({required ForumFilter filter, required ForumSort sort, int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(Report report) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _Composer extends ComposerController {
-  _Composer() : super(_FakeRepo());
+  _Composer() : super(FakeForumRepository());
 }
 
 class _Auth extends AuthNotifier {

--- a/test/widgets/forum_moderator_menu_test.dart
+++ b/test/widgets/forum_moderator_menu_test.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadDetailController {
   _FakeController() : super(_DummyRepo(), 't1') {
@@ -16,59 +16,12 @@ class _FakeController extends ThreadDetailController {
   }
 }
 
-class _DummyRepo implements ForumRepository {
+class _DummyRepo extends FakeForumRepository {
   bool pinnedCalled = false;
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Stream<List<Thread>> queryThreads(
-          {required ForumFilter filter,
-          required ForumSort sort,
-          int limit = 20,
-          DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost(
-          {required String threadId,
-          required String postId,
-          required String content}) async {}
-  @override
-  Future<void> deletePost(
-          {required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(report) async {}
-  @override
-  Future<void> unvoteOnPost(
-          {required String postId, required String userId}) async {}
-  @override
-  Future<bool> hasVoted(
-          {required String postId, required String userId}) async =>
-      false;
-  @override
-  Stream<Thread> watchThread(String threadId) => const Stream.empty();
   @override
   Future<void> setThreadPinned(String threadId, bool pinned) async {
     pinnedCalled = true;
   }
-
-  @override
-  Future<void> setThreadLocked(String threadId, bool locked) async {}
 }
 
 void main() {

--- a/test/widgets/forum_navigation_test.dart
+++ b/test/widgets/forum_navigation_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/features/forum/providers/thread_list_controller.dart';
@@ -11,35 +10,11 @@ import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/routes/app_route.dart';
 import 'package:tipsterino/screens/forum/forum_screen.dart';
-
-class _FakeRepo implements ForumRepository {
-  @override
-  Stream<List<Thread>> queryThreads({required ForumFilter filter, required ForumSort sort, int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(post) async {}
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(report) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeController extends ThreadListController {
   _FakeController(List<Thread> threads)
-      : super(_FakeRepo(), const ForumFilterState()) {
+      : super(FakeForumRepository(), const ForumFilterState()) {
     state = AsyncData(threads);
   }
 }

--- a/test/widgets/forum_screen_pagination_test.dart
+++ b/test/widgets/forum_screen_pagination_test.dart
@@ -2,19 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
-import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/features/forum/providers/thread_list_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/forum_screen.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _LoadMoreController extends ThreadListController {
   _LoadMoreController(List<Thread> threads)
-      : super(_FakeRepo(), const ForumFilterState()) {
+      : super(FakeForumRepository(), const ForumFilterState()) {
     state = AsyncData(threads);
   }
 
@@ -26,42 +24,6 @@ class _LoadMoreController extends ThreadListController {
   }
 }
 
-class _FakeRepo implements ForumRepository {
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(Report report) async {}
-}
 
 void main() {
   testWidgets('scrolling triggers loadMore', (tester) async {

--- a/test/widgets/forum_screen_test.dart
+++ b/test/widgets/forum_screen_test.dart
@@ -2,9 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
-import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/features/forum/providers/thread_list_controller.dart';
@@ -12,68 +9,11 @@ import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/l10n/app_localizations_en.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/forum_screen.dart';
-
-class _FakeRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  }) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(
-    String threadId, {
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(
-    String fixtureId, {
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({
-    required String postId,
-    required String userId,
-  }) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeThreadListController extends ThreadListController {
   _FakeThreadListController(AsyncValue<List<Thread>> initial)
-      : super(_FakeRepo(), const ForumFilterState()) {
+      : super(FakeForumRepository(), const ForumFilterState()) {
     state = initial;
   }
 }

--- a/test/widgets/forum_vote_test.dart
+++ b/test/widgets/forum_vote_test.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/models/auth_state.dart';
@@ -13,8 +11,9 @@ import 'package:tipsterino/providers/auth_provider.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/post_item.dart';
 import 'package:tipsterino/services/auth_service.dart';
+import '../mocks/fake_forum_repository.dart';
 
-class _Repo implements ForumRepository {
+class _Repo extends FakeForumRepository {
   bool voted = false;
   bool unvoted = false;
   @override
@@ -30,29 +29,6 @@ class _Repo implements ForumRepository {
   @override
   Future<bool> hasVoted({required String postId, required String userId}) async => false;
 
-  // unused
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> queryThreads({required ForumFilter filter, required ForumSort sort, int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId, {int limit = 20, DateTime? startAfter}) => const Stream.empty();
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> reportPost(report) async {}
-  @override
-  Stream<Thread> watchThread(String threadId) => const Stream.empty();
 }
 
 class _Auth extends AuthNotifier {

--- a/test/widgets/new_thread_screen_test.dart
+++ b/test/widgets/new_thread_screen_test.dart
@@ -3,12 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/features/forum/providers/composer_controller.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/l10n/app_localizations_en.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
@@ -19,60 +16,10 @@ import 'package:tipsterino/models/user.dart';
 import 'package:tipsterino/routes/app_route.dart';
 
 import '../mocks/mock_auth_service.dart';
-
-class _FakeRepo implements ForumRepository {
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  }) async {}
-
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-}
+import '../mocks/fake_forum_repository.dart';
 
 class _FakeComposer extends ComposerController {
-  _FakeComposer() : super(_FakeRepo());
+  _FakeComposer() : super(FakeForumRepository());
   bool called = false;
 
   @override

--- a/test/widgets/post_item_report_test.dart
+++ b/test/widgets/post_item_report_test.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/l10n/app_localizations_en.dart';
@@ -16,58 +13,15 @@ import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/post_item.dart';
 import 'package:tipsterino/services/auth_service.dart';
 
-class _DummyRepo implements ForumRepository {
-  Report? lastReport;
+import '../mocks/fake_forum_repository.dart';
 
-  @override
-  Stream<List<Post>> getPostsByThread(
-    String threadId, {
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
+class _DummyRepo extends FakeForumRepository {
+  Report? lastReport;
 
   @override
   Future<void> reportPost(Report report) async {
     lastReport = report;
   }
-
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Future<void> updatePost({
-    required String threadId,
-    required String postId,
-    required String content,
-  }) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
 }
 
 class _FakeController extends ThreadDetailController {

--- a/test/widgets/post_item_test.dart
+++ b/test/widgets/post_item_test.dart
@@ -3,11 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/models/user.dart';
 import 'package:tipsterino/models/auth_state.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
@@ -16,6 +12,7 @@ import 'package:tipsterino/screens/forum/post_item.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 
 import 'package:tipsterino/services/auth_service.dart';
+import '../mocks/fake_forum_repository.dart';
 class _StubAuthService implements AuthService {
   @override
   Stream<User?> authStateChanges() async* {}
@@ -58,62 +55,18 @@ class FakeAuthNotifier extends AuthNotifier {
   }
 }
 
-class FakeForumRepository implements ForumRepository {
+class TestForumRepository extends FakeForumRepository {
   bool voteCalled = false;
 
   @override
   Future<void> voteOnPost({required String postId, required String userId}) async {
     voteCalled = true;
   }
-
-  // Unused methods in test
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> reportPost(Report report) async {}
-
-  @override
-  Future<void> addPost(Post post) async {}
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-
-  @override
-  Future<void> deleteThread(String threadId) async {}
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> updatePost(
-          {required String threadId,
-          required String postId,
-          required String content}) async {}
-
-  @override
-  Future<void> deletePost(
-          {required String threadId, required String postId}) async {}
 }
 
 void main() {
   testWidgets('upvote calls repository', (tester) async {
-    final repo = FakeForumRepository();
+    final repo = TestForumRepository();
     final post = Post(
       id: 'p1',
       threadId: 't1',

--- a/test/widgets/thread_view_pagination_test.dart
+++ b/test/widgets/thread_view_pagination_test.dart
@@ -2,12 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:tipsterino/features/forum/data/forum_repository.dart';
 import 'package:tipsterino/features/forum/domain/post.dart';
-import 'package:tipsterino/features/forum/domain/report.dart';
-import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
-import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/models/auth_state.dart';
@@ -15,10 +11,11 @@ import 'package:tipsterino/models/user.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
 import '../mocks/mock_auth_service.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
+import '../mocks/fake_forum_repository.dart';
 
 class _LoadMoreDetailController extends ThreadDetailController {
   _LoadMoreDetailController(List<Post> posts)
-      : super(_FakeRepo(), 't1') {
+      : super(FakeForumRepository(), 't1') {
     state = AsyncData(posts);
   }
 
@@ -30,42 +27,6 @@ class _LoadMoreDetailController extends ThreadDetailController {
   }
 }
 
-class _FakeRepo implements ForumRepository {
-  @override
-  Stream<List<Post>> getPostsByThread(String threadId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Stream<List<Thread>> queryThreads({
-    required ForumFilter filter,
-    required ForumSort sort,
-    int limit = 20,
-    DateTime? startAfter,
-  }) => const Stream.empty();
-
-  @override
-  Stream<List<Thread>> getThreadsByFixture(String fixtureId,
-          {int limit = 20, DateTime? startAfter}) =>
-      const Stream.empty();
-
-  @override
-  Future<void> addThread(Thread thread) async {}
-  @override
-  Future<void> updateThread(String threadId, Map<String, dynamic> data) async {}
-  @override
-  Future<void> deleteThread(String threadId) async {}
-  @override
-  Future<void> addPost(Post post) async {}
-  @override
-  Future<void> updatePost({required String threadId, required String postId, required String content}) async {}
-  @override
-  Future<void> deletePost({required String threadId, required String postId}) async {}
-  @override
-  Future<void> voteOnPost({required String postId, required String userId}) async {}
-  @override
-  Future<void> reportPost(Report report) async {}
-}
 
 class _FakeAuthNotifier extends AuthNotifier {
   _FakeAuthNotifier() : super(MockAuthService()) {


### PR DESCRIPTION
## Summary
- add reusable `FakeForumRepository` for tests
- clean up imports and ordering in forum files
- regenerate localization outputs

## Testing
- `flutter analyze --no-fatal-warnings lib test integration_test bin tool`


------
https://chatgpt.com/codex/tasks/task_e_68c07f923298832f9e8ce359d0bc826c