### PR TITLE
fix: replace initialValue in dropdowns

### DIFF
--- a/lib/screens/forum/new_thread_screen.dart
+++ b/lib/screens/forum/new_thread_screen.dart
@@ -104,7 +104,7 @@ class _NewThreadScreenState extends ConsumerState<NewThreadScreen> {
           child: Column(
             children: [
               DropdownButtonFormField<ThreadType>(
-                initialValue: _type,
+                value: _type,
                 decoration: InputDecoration(labelText: loc.thread_type),
                 items: [
                   DropdownMenuItem(

--- a/lib/screens/forum/post_item.dart
+++ b/lib/screens/forum/post_item.dart
@@ -73,7 +73,7 @@ class _PostItemState extends ConsumerState<PostItem> {
           mainAxisSize: MainAxisSize.min,
           children: [
               DropdownButtonFormField<String>(
-                initialValue: reason,
+                value: reason,
                 decoration:
                     InputDecoration(labelText: loc.report_reason_label),
               items: [

--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -157,10 +157,10 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
               maxLength: 160,
             ),
             const SizedBox(height: 16),
-              DropdownButtonFormField<String>(
-                initialValue: _team,
-                decoration: InputDecoration(labelText: loc.team_hint),
-                items: const [
+            DropdownButtonFormField<String>(
+              value: _team,
+              decoration: InputDecoration(labelText: loc.team_hint),
+              items: const [
                 DropdownMenuItem(value: 'teamA', child: Text('Team A')),
                 DropdownMenuItem(value: 'teamB', child: Text('Team B')),
               ],

--- a/lib/widgets/events_filter_bar.dart
+++ b/lib/widgets/events_filter_bar.dart
@@ -122,7 +122,7 @@ class _DatePill extends StatelessWidget {
 class _Drop extends StatelessWidget {
   final String label;
   final List<String> items;
-    final String? value;
+  final String? value;
   final ValueChanged<String?> onChanged;
   const _Drop(this.label, this.items, this.value, this.onChanged);
   @override
@@ -130,7 +130,7 @@ class _Drop extends StatelessWidget {
       return DropdownButtonFormField<String>(
         isDense: true,
         isExpanded: true,
-        initialValue: value ?? (items.isNotEmpty ? items.first : null),
+        value: value ?? (items.isNotEmpty ? items.first : null),
         items: items
           .map(
             (e) => DropdownMenuItem(


### PR DESCRIPTION
## Summary
- replace deprecated `initialValue` with `value` on dropdown widgets

## Testing
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib test integration_test bin tool` *(failed: Failed to update packages)*
- `flutter test --concurrency=4` *(failed: Failed to update packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c088902620832f991651cdb067fa9b