### PR TITLE
fix: enforce moderator-only post deletion

### DIFF
--- a/canvases/screens/forum_module_moderator_and_aggregation_fixup_2025_09_09.md
+++ b/canvases/screens/forum_module_moderator_and_aggregation_fixup_2025_09_09.md
@@ -54,7 +54,7 @@ A fórum modul moderátori funkcióinak (pin/lock) és a szerveroldali szavazat�
 
 **Pipálható checklista**
 
-* [ ] P0: törlés UI elrejtése nem‑moderátornál + repo guard
+* [x] P0: törlés UI elrejtése nem‑moderátornál + repo guard
 * [ ] Moderátor claim provider bekötése (custom claims)
 * [ ] Functions: votesCount inkrement/dekrement, tesztekkel
 * [ ] E2E: teljes happy‑path + lock/pin forgatókönyv

--- a/lib/features/forum/data/forum_repository.dart
+++ b/lib/features/forum/data/forum_repository.dart
@@ -3,6 +3,11 @@ import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/forum_filter_state.dart';
 
+/// Thrown when the current user lacks permission for a forum action.
+class ForumPermissionException implements Exception {
+  const ForumPermissionException();
+}
+
 abstract class ForumRepository {
   Stream<List<Thread>> getThreadsByFixture(
     String fixtureId, {
@@ -43,10 +48,7 @@ abstract class ForumRepository {
     required String content,
   });
 
-  Future<void> deletePost({
-    required String threadId,
-    required String postId,
-  });
+  Future<void> deletePost({required String threadId, required String postId});
 
   /// Creates a vote document; `votesCount` is updated by server triggers.
   Future<void> voteOnPost({required String postId, required String userId});

--- a/lib/providers/forum_provider.dart
+++ b/lib/providers/forum_provider.dart
@@ -13,7 +13,10 @@ import 'admin_provider.dart';
 
 /// Provides the [ForumRepository] implementation.
 final forumRepositoryProvider = Provider<ForumRepository>(
-  (ref) => FirestoreForumRepository(FirebaseFirestore.instance),
+  (ref) => FirestoreForumRepository(
+    FirebaseFirestore.instance,
+    () => ref.read(isModeratorProvider),
+  ),
 );
 
 /// Holds the current filter and sort state.
@@ -53,17 +56,14 @@ final threadDetailControllerProviderFamily =
     );
 
 final threadDetailLoadingProviderFamily = Provider.family<bool, String>(
-  (ref, threadId) =>
-      ref.watch(threadDetailControllerProviderFamily(threadId).notifier)
-          .isLoadingMore,
+  (ref, threadId) => ref
+      .watch(threadDetailControllerProviderFamily(threadId).notifier)
+      .isLoadingMore,
 );
 
 /// Provides a single thread stream by id.
 final threadProviderFamily = StreamProvider.family<Thread, String>(
-  (ref, threadId) =>
-      ref.watch(forumRepositoryProvider).watchThread(threadId),
+  (ref, threadId) => ref.watch(forumRepositoryProvider).watchThread(threadId),
 );
 
-final isModeratorProvider = Provider<bool>(
-  (ref) => ref.watch(isAdminProvider),
-);
+final isModeratorProvider = Provider<bool>((ref) => ref.watch(isAdminProvider));

--- a/test/features/forum/data/forum_repository_test.dart
+++ b/test/features/forum/data/forum_repository_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   setUp(() {
     fs = FakeFirebaseFirestore();
-    repo = FirestoreForumRepository(fs);
+    repo = FirestoreForumRepository(fs, () => true);
   });
 
   test('addPost writes to thread subcollection', () async {
@@ -157,7 +157,8 @@ void main() {
     expect(
       (threadSnap['lastActivityAt'] as Timestamp).toDate(),
       DateTime.fromMillisecondsSinceEpoch(
-          now.add(const Duration(minutes: 1)).millisecondsSinceEpoch),
+        now.add(const Duration(minutes: 1)).millisecondsSinceEpoch,
+      ),
     );
   });
 }

--- a/test/integration/forum_happy_path_test.dart
+++ b/test/integration/forum_happy_path_test.dart
@@ -10,7 +10,7 @@ import 'package:tipsterino/features/forum/providers/thread_detail_controller.dar
 void main() {
   test('forum happy path: thread, comment, vote, report', () async {
     final fs = FakeFirebaseFirestore();
-    final repo = FirestoreForumRepository(fs);
+    final repo = FirestoreForumRepository(fs, () => true);
     final composer = ComposerController(repo);
 
     final now = DateTime.now();

--- a/test/widgets/forum/post_item_delete_visibility_test.dart
+++ b/test/widgets/forum/post_item_delete_visibility_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
+import 'package:tipsterino/l10n/app_localizations.dart';
+import 'package:tipsterino/models/auth_state.dart';
+import 'package:tipsterino/models/user.dart';
+import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/forum_provider.dart';
+import 'package:tipsterino/screens/forum/post_item.dart';
+
+import '../../mocks/mock_auth_service.dart';
+import '../../mocks/fake_forum_repository.dart';
+
+class _FakeAuth extends AuthNotifier {
+  _FakeAuth() : super(MockAuthService()) {
+    state = AuthState(
+      user: User(id: 'u1', email: '', displayName: ''),
+    );
+  }
+}
+
+class _DummyController extends ThreadDetailController {
+  _DummyController() : super(FakeForumRepository(), 't1');
+}
+
+final _post = Post(
+  id: 'p1',
+  threadId: 't1',
+  userId: 'u2',
+  type: PostType.comment,
+  content: 'Hello',
+  createdAt: DateTime(2024),
+);
+
+Widget _buildApp({required bool isModerator}) {
+  return ProviderScope(
+    overrides: [
+      authProvider.overrideWith((ref) => _FakeAuth()),
+      threadDetailControllerProviderFamily(
+        't1',
+      ).overrideWith((ref) => _DummyController()),
+      isModeratorProvider.overrideWithValue(isModerator),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: PostItem(post: _post)),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('non-moderator does not see delete button', (tester) async {
+    await tester.pumpWidget(_buildApp(isModerator: false));
+    expect(find.byIcon(Icons.delete), findsNothing);
+  });
+
+  testWidgets('moderator sees delete button', (tester) async {
+    await tester.pumpWidget(_buildApp(isModerator: true));
+    expect(find.byIcon(Icons.delete), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- restrict delete button to moderators and handle unauthorized attempts
- guard post deletions in Firestore repository with a moderator check
- add widget test for delete icon visibility and mark canvas checklist

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --concurrency=4` *(fails: A value of type 'AppBarThemeData' can't be assigned to a variable of type 'AppBarTheme')*

------
https://chatgpt.com/codex/tasks/task_e_68c0928b113c832f8c08396f63e2baca