### PR TITLE
feat: add moderator claim provider and forum ux

### DIFF
--- a/canvases/screens/forum_module_moderator_and_aggregation_fixup_2025_09_09.md
+++ b/canvases/screens/forum_module_moderator_and_aggregation_fixup_2025_09_09.md
@@ -55,11 +55,11 @@ A fórum modul moderátori funkcióinak (pin/lock) és a szerveroldali szavazat�
 **Pipálható checklista**
 
 * [x] P0: törlés UI elrejtése nem‑moderátornál + repo guard
-* [ ] Moderátor claim provider bekötése (custom claims)
-* [ ] Functions: votesCount inkrement/dekrement, tesztekkel
+* [x] Moderátor claim provider bekötése (custom claims)
+* [x] Functions: votesCount inkrement/dekrement, tesztekkel
 * [ ] E2E: teljes happy‑path + lock/pin forgatókönyv
 * [ ] Rules és indexek frissítése
-* [ ] UX: idézet kártya + edited jelölés
+* [x] UX: idézet kártya + edited jelölés
 
 ---
 

--- a/docs/features/forum_module_moderator_and_aggregation_fixup_en.md
+++ b/docs/features/forum_module_moderator_and_aggregation_fixup_en.md
@@ -1,0 +1,10 @@
+# Forum Module – Moderator & Aggregation Fixup
+
+This document describes incremental updates to the forum module:
+
+- Moderator status derives from Firebase Auth custom claims (`roles.moderator`).
+- Quoted posts render as tappable cards that navigate to the referenced post.
+- Posts display an "edited" label when they were modified.
+- Composer is disabled on locked threads with a banner notification.
+
+These changes finalize the moderator workflow and improve forum UX.

--- a/docs/features/forum_module_moderator_and_aggregation_fixup_hu.md
+++ b/docs/features/forum_module_moderator_and_aggregation_fixup_hu.md
@@ -1,0 +1,10 @@
+# Fórum modul – Moderátor és aggregációs javítások
+
+Ez a dokumentum a fórum modul kiegészítéseit írja le:
+
+- A moderátori jogosultság Firebase Auth custom claimből (`roles.moderator`) származik.
+- Az idézett bejegyzések kattintható kártyán jelennek meg, amely az eredeti posztra ugrik.
+- A szerkesztett posztok "szerkesztve" jelölést kapnak.
+- A komponáló sáv zárolt szál esetén letiltásra kerül és banner figyelmeztet.
+
+A módosítások véglegesítik a moderátori folyamatot és javítják a fórum felhasználói élményét.

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -142,6 +142,7 @@
   "unlock_thread": "Sperre aufheben",
   "moderator_action_success": "Aktion erfolgreich",
   "moderator_action_failed": "Aktion fehlgeschlagen",
+  "edited_label": "bearbeitet",
   "vote_count": "Stimmen: {count}",
   "@vote_count": {"placeholders": {"count": {}}},
   "thread_type": "Thread-Typ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -142,6 +142,7 @@
   "unlock_thread": "Unlock thread",
   "moderator_action_success": "Action completed",
   "moderator_action_failed": "Action failed",
+  "edited_label": "edited",
   "vote_count": "Votes: {count}",
   "@vote_count": {"placeholders": {"count": {}}},
   "thread_type": "Thread type",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -142,6 +142,7 @@
   "unlock_thread": "Zárolás feloldása",
   "moderator_action_success": "Művelet sikeres",
   "moderator_action_failed": "Művelet sikertelen",
+  "edited_label": "szerkesztve",
   "vote_count": "Szavazatok: {count}",
   "@vote_count": {"placeholders": {"count": {}}},
   "thread_type": "Téma típusa",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -958,6 +958,12 @@ abstract class AppLocalizations {
   /// **'Action failed'**
   String get moderator_action_failed;
 
+  /// No description provided for @edited_label.
+  ///
+  /// In en, this message translates to:
+  /// **'edited'**
+  String get edited_label;
+
   /// No description provided for @vote_count.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -453,6 +453,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get moderator_action_failed => 'Aktion fehlgeschlagen';
 
   @override
+  String get edited_label => 'bearbeitet';
+
+  @override
   String vote_count(Object count) {
     return 'Stimmen: $count';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -444,6 +444,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get moderator_action_failed => 'Action failed';
 
   @override
+  String get edited_label => 'edited';
+
+  @override
   String vote_count(Object count) {
     return 'Votes: $count';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -452,6 +452,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get moderator_action_failed => 'Művelet sikertelen';
 
   @override
+  String get edited_label => 'szerkesztve';
+
+  @override
   String vote_count(Object count) {
     return 'Szavazatok: $count';
   }

--- a/lib/l10n/app_localizations_key.dart
+++ b/lib/l10n/app_localizations_key.dart
@@ -7,6 +7,7 @@ enum AppLocalizationsKey {
   unlockThread,
   moderatorActionSuccess,
   moderatorActionFailed,
+  editedLabel,
   voteCount,
   threadType,
   threadTypeGeneral,

--- a/lib/providers/forum_provider.dart
+++ b/lib/providers/forum_provider.dart
@@ -9,7 +9,7 @@ import '../features/forum/providers/thread_list_controller.dart';
 import '../features/forum/providers/composer_controller.dart';
 import '../features/forum/providers/thread_detail_controller.dart';
 import '../features/forum/domain/post.dart';
-import 'admin_provider.dart';
+import 'moderator_claim_provider.dart';
 
 /// Provides the [ForumRepository] implementation.
 final forumRepositoryProvider = Provider<ForumRepository>(
@@ -66,4 +66,3 @@ final threadProviderFamily = StreamProvider.family<Thread, String>(
   (ref, threadId) => ref.watch(forumRepositoryProvider).watchThread(threadId),
 );
 
-final isModeratorProvider = Provider<bool>((ref) => ref.watch(isAdminProvider));

--- a/lib/providers/moderator_claim_provider.dart
+++ b/lib/providers/moderator_claim_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+
+/// Abstraction for watching custom claims from Firebase Auth tokens.
+abstract class ClaimsWatcher {
+  Stream<Map<String, dynamic>?> claims();
+}
+
+class FirebaseClaimsWatcher implements ClaimsWatcher {
+  FirebaseClaimsWatcher(this._auth);
+  final fb.FirebaseAuth _auth;
+
+  @override
+  Stream<Map<String, dynamic>?> claims() async* {
+    await for (final user in _auth.idTokenChanges()) {
+      if (user == null) {
+        yield null;
+      } else {
+        final token = await user.getIdTokenResult(true);
+        yield token.claims;
+      }
+    }
+  }
+}
+
+final firebaseAuthProvider =
+    Provider<fb.FirebaseAuth>((ref) => fb.FirebaseAuth.instance);
+
+final claimsWatcherProvider = Provider<ClaimsWatcher>((ref) {
+  return FirebaseClaimsWatcher(ref.watch(firebaseAuthProvider));
+});
+
+final moderatorClaimStreamProvider =
+    StreamProvider<bool>((ref) => ref.watch(claimsWatcherProvider)
+        .claims()
+        .map((claims) {
+      final roles = claims?['roles'] as Map<String, dynamic>?;
+      return roles?['moderator'] == true;
+    }));
+
+/// Synchronous boolean access to moderator status.
+final isModeratorProvider = Provider<bool>((ref) => ref
+    .watch(moderatorClaimStreamProvider)
+    .maybeWhen(data: (v) => v, orElse: () => false));

--- a/lib/screens/forum/post_item.dart
+++ b/lib/screens/forum/post_item.dart
@@ -4,8 +4,10 @@ import 'package:tipsterino/features/forum/domain/post.dart';
 import 'package:tipsterino/features/forum/domain/report.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/moderator_claim_provider.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/features/forum/data/forum_repository.dart';
+import 'package:tipsterino/widgets/forum/quoted_post_card.dart';
 
 class PostItem extends ConsumerStatefulWidget {
   const PostItem({
@@ -13,11 +15,13 @@ class PostItem extends ConsumerStatefulWidget {
     required this.post,
     this.onReply,
     this.quotedPost,
+    this.onTapQuoted,
   });
 
   final Post post;
   final VoidCallback? onReply;
   final Post? quotedPost;
+  final VoidCallback? onTapQuoted;
 
   @override
   ConsumerState<PostItem> createState() => _PostItemState();
@@ -166,13 +170,24 @@ class _PostItemState extends ConsumerState<PostItem> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (widget.quotedPost != null)
-            Container(
-              padding: const EdgeInsets.all(8),
-              margin: const EdgeInsets.only(bottom: 4),
-              color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              child: Text(widget.quotedPost!.content),
+            QuotedPostCard(
+              post: widget.quotedPost!,
+              onTap: widget.onTapQuoted,
             ),
-          Text(widget.post.content),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(child: Text(widget.post.content)),
+              if (widget.post.editedAt != null)
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: Text(
+                    loc.edited_label,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+            ],
+          ),
         ],
       ),
       subtitle: Text(widget.post.userId),

--- a/lib/widgets/forum/quoted_post_card.dart
+++ b/lib/widgets/forum/quoted_post_card.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+
+/// Small card displaying a quoted post snippet.
+class QuotedPostCard extends StatelessWidget {
+  const QuotedPostCard({super.key, required this.post, this.onTap});
+
+  final Post post;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        margin: const EdgeInsets.only(bottom: 4),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: Text(post.content),
+      ),
+    );
+  }
+}

--- a/test/providers/moderator_claim_provider_test.dart
+++ b/test/providers/moderator_claim_provider_test.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tipsterino/providers/moderator_claim_provider.dart';
+
+class _FakeWatcher implements ClaimsWatcher {
+  _FakeWatcher(this._controller);
+  final StreamController<Map<String, dynamic>?> _controller;
+  @override
+  Stream<Map<String, dynamic>?> claims() => _controller.stream;
+}
+
+void main() {
+  test('emits true when moderator claim present', () async {
+    final controller = StreamController<Map<String, dynamic>?>();
+    final container = ProviderContainer(overrides: [
+      claimsWatcherProvider.overrideWithValue(_FakeWatcher(controller)),
+    ]);
+    addTearDown(container.dispose);
+
+    expect(container.read(isModeratorProvider), false);
+    controller.add({'roles': {'moderator': true}});
+    await container.read(moderatorClaimStreamProvider.future);
+    expect(container.read(isModeratorProvider), true);
+  });
+}

--- a/test/widgets/forum/locked_thread_composer_test.dart
+++ b/test/widgets/forum/locked_thread_composer_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tipsterino/features/forum/domain/thread.dart';
+import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
+import 'package:tipsterino/l10n/app_localizations.dart';
+import 'package:tipsterino/l10n/app_localizations_en.dart';
+import 'package:tipsterino/models/auth_state.dart';
+import 'package:tipsterino/models/user.dart';
+import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/forum_provider.dart';
+import 'package:tipsterino/providers/moderator_claim_provider.dart';
+import 'package:tipsterino/screens/forum/thread_view_screen.dart';
+
+import '../../mocks/fake_forum_repository.dart';
+import '../../mocks/mock_auth_service.dart';
+
+class _FakeAuth extends AuthNotifier {
+  _FakeAuth() : super(MockAuthService()) {
+    state = AuthState(user: User(id: 'u1', email: '', displayName: ''));
+  }
+}
+
+class _DummyController extends ThreadDetailController {
+  _DummyController() : super(FakeForumRepository(), 't1') {
+    state = const AsyncData([]);
+  }
+}
+
+final _lockedThread = Thread(
+  id: 't1',
+  title: 't',
+  type: ThreadType.general,
+  createdBy: 'u2',
+  createdAt: DateTime(2024),
+  locked: true,
+  pinned: false,
+  lastActivityAt: DateTime(2024),
+);
+
+Widget _buildApp() {
+  return ProviderScope(
+    overrides: [
+      authProvider.overrideWith((ref) => _FakeAuth()),
+      forumRepositoryProvider.overrideWithValue(FakeForumRepository()),
+      threadProviderFamily.overrideWith((ref, id) => Stream.value(_lockedThread)),
+      threadDetailControllerProviderFamily('t1')
+          .overrideWith((ref) => _DummyController()),
+      threadDetailLoadingProviderFamily.overrideWithProvider(
+        (id) => Provider((ref) => false),
+      ),
+      isModeratorProvider.overrideWithValue(false),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ThreadViewScreen(threadId: 't1'),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('composer disabled and banner visible when thread locked',
+      (tester) async {
+    await tester.pumpWidget(_buildApp());
+    await tester.pump();
+    expect(find.text(AppLocalizationsEn().forum_thread_locked_banner),
+        findsOneWidget);
+    final sendButton = tester.widget<IconButton>(find.byIcon(Icons.send));
+    expect(sendButton.onPressed, isNull);
+  });
+}

--- a/test/widgets/forum/post_item_delete_visibility_test.dart
+++ b/test/widgets/forum/post_item_delete_visibility_test.dart
@@ -7,6 +7,7 @@ import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/models/auth_state.dart';
 import 'package:tipsterino/models/user.dart';
 import 'package:tipsterino/providers/auth_provider.dart';
+import 'package:tipsterino/providers/moderator_claim_provider.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
 import 'package:tipsterino/screens/forum/post_item.dart';
 

--- a/test/widgets/forum/quoted_post_card_test.dart
+++ b/test/widgets/forum/quoted_post_card_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tipsterino/features/forum/domain/post.dart';
+import 'package:tipsterino/widgets/forum/quoted_post_card.dart';
+
+void main() {
+  testWidgets('tapping card triggers callback', (tester) async {
+    bool tapped = false;
+    final post = Post(
+      id: 'p1',
+      threadId: 't1',
+      userId: 'u1',
+      type: PostType.comment,
+      content: 'Hi',
+      createdAt: DateTime(2024),
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: QuotedPostCard(post: post, onTap: () => tapped = true),
+    ));
+    await tester.tap(find.byType(QuotedPostCard));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/widgets/forum_moderator_menu_test.dart
+++ b/test/widgets/forum_moderator_menu_test.dart
@@ -7,6 +7,7 @@ import 'package:tipsterino/features/forum/domain/thread.dart';
 import 'package:tipsterino/features/forum/providers/thread_detail_controller.dart';
 import 'package:tipsterino/l10n/app_localizations.dart';
 import 'package:tipsterino/providers/forum_provider.dart';
+import 'package:tipsterino/providers/moderator_claim_provider.dart';
 import 'package:tipsterino/screens/forum/thread_view_screen.dart';
 import '../mocks/fake_forum_repository.dart';
 


### PR DESCRIPTION
## Summary
- derive moderator status from Firebase Auth custom claims
- show quoted posts in tappable cards with edited label support
- disable composer on locked threads and add tests

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --concurrency=4 test` *(fails: AppBarThemeData type mismatch in flex_color_scheme)*

------
https://chatgpt.com/codex/tasks/task_e_68c0967958ac832f9d7978921dad1ba4