### PR TITLE
test: add fake file fallback

### DIFF
--- a/test/services/profile_service_avatar_test.dart
+++ b/test/services/profile_service_avatar_test.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:firebase_storage/firebase_storage.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:tipsterino/services/profile_service.dart';
+
 import 'package:tipsterino/models/user_model.dart';
+import 'package:tipsterino/services/profile_service.dart';
 
 class MockFirebaseStorage extends Mock implements FirebaseStorage {}
 
@@ -15,9 +17,11 @@ class MockUploadTask extends Mock implements UploadTask {}
 
 class MockTaskSnapshot extends Mock implements TaskSnapshot {}
 
+class FakeFile extends Fake implements File {}
+
 void main() {
   setUpAll(() {
-    registerFallbackValue(File('fallback.png'));
+    registerFallbackValue(FakeFile());
     registerFallbackValue(Uint8List(0));
   });
   group('ProfileService.uploadAvatar', () {


### PR DESCRIPTION
## Summary
- ensure ProfileService avatar test registers a fake File fallback for mocktail

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test test/services/profile_service_avatar_test.dart --concurrency=4 --test-randomize-ordering-seed random`


------
https://chatgpt.com/codex/tasks/task_e_68c1c61220a8832fb4bef4edaf13ff80