### PR TITLE
fix: repair failing tests

### DIFF
--- a/test/services/bet_slip_service_test.dart
+++ b/test/services/bet_slip_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:tipsterino/models/tip_model.dart';
 import 'package:tipsterino/services/bet_slip_service.dart';
@@ -92,6 +93,7 @@ class FakeFirebaseFirestore extends Fake implements FirebaseFirestore {
 }
 
 void main() {
+  setUpAll(() => dotenv.testLoad(fileInput: 'USE_SUPABASE=false'));
   test('submitTicket writes ticket and calls CoinService', () async {
     final firestore = FakeFirebaseFirestore();
     final coinService = FakeCoinService(firestore);

--- a/test/services/experiment_service_test.dart
+++ b/test/services/experiment_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tipsterino/services/experiment_service.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class FakeRemoteConfig extends Fake implements FirebaseRemoteConfig {
   String variant;
@@ -18,6 +19,7 @@ class FakeRemoteConfig extends Fake implements FirebaseRemoteConfig {
 }
 
 void main() {
+  setUpAll(() => dotenv.testLoad(fileInput: 'USE_SUPABASE=false'));
   group('ExperimentService', () {
     test('returns cached variant when fresh', () async {
       final ts = DateTime.now().millisecondsSinceEpoch;

--- a/test/widgets/forum/locked_thread_composer_test.dart
+++ b/test/widgets/forum/locked_thread_composer_test.dart
@@ -51,10 +51,11 @@ Widget _buildApp() {
       ),
       isModeratorProvider.overrideWithValue(false),
     ],
-    child: const MaterialApp(
+    child: MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: ThreadViewScreen(threadId: 't1'),
+      home: const ThreadViewScreen(threadId: 't1'),
     ),
   );
 }
@@ -68,7 +69,8 @@ void main() {
         find.text(AppLocalizationsEn().forum_thread_locked_banner),
         findsWidgets,
       );
-    final sendButton = tester.widget<IconButton>(find.byIcon(Icons.send));
+    final sendButton =
+        tester.widget<IconButton>(find.widgetWithIcon(IconButton, Icons.send));
     expect(sendButton.onPressed, isNull);
   });
 }

--- a/test/widgets/forum_moderator_menu_test.dart
+++ b/test/widgets/forum_moderator_menu_test.dart
@@ -42,14 +42,18 @@ void main() {
         isModeratorProvider.overrideWithValue(true),
         forumRepositoryProvider.overrideWithValue(_DummyRepo()),
       ],
-        child: const MaterialApp(
+        child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: ThreadViewScreen(threadId: 't1'),
+          home: const ThreadViewScreen(threadId: 't1'),
         ),
     ));
       await tester.pumpAndSettle();
-    expect(find.byType(PopupMenuButton), findsOneWidget);
+    expect(
+      find.byWidgetPredicate((w) => w is PopupMenuButton),
+      findsOneWidget,
+    );
 
     await tester.pumpWidget(ProviderScope(
       overrides: [
@@ -58,14 +62,18 @@ void main() {
         isModeratorProvider.overrideWithValue(false),
         forumRepositoryProvider.overrideWithValue(_DummyRepo()),
       ],
-        child: const MaterialApp(
+        child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: ThreadViewScreen(threadId: 't1'),
+          home: const ThreadViewScreen(threadId: 't1'),
         ),
     ));
       await tester.pumpAndSettle();
-    expect(find.byType(PopupMenuButton), findsNothing);
+    expect(
+      find.byWidgetPredicate((w) => w is PopupMenuButton),
+      findsNothing,
+    );
   });
 
   testWidgets('pin action calls repository', (tester) async {
@@ -85,10 +93,11 @@ void main() {
         isModeratorProvider.overrideWithValue(true),
         forumRepositoryProvider.overrideWithValue(repo),
       ],
-        child: const MaterialApp(
+        child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: ThreadViewScreen(threadId: 't1'),
+          home: const ThreadViewScreen(threadId: 't1'),
         ),
     ));
     await tester.pump();


### PR DESCRIPTION
## Summary
- load dotenv before bet slip and experiment service tests
- harden forum moderator menu test and disable Material 3 shaders
- fix locked thread composer test to target the send IconButton

## Testing
- `flutter analyze --no-fatal-infos lib test integration_test bin tool`
- `flutter test --no-test-assets test/services/bet_slip_service_test.dart`
- `flutter test --no-test-assets test/services/experiment_service_test.dart`
- `flutter test --no-test-assets test/widgets/forum_moderator_menu_test.dart`
- `flutter test --no-test-assets test/widgets/forum/locked_thread_composer_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68c1de530cf0832f89fd596a09c45ad0